### PR TITLE
Improve navigation handling and empty state behavior in calculator output screen

### DIFF
--- a/apps/mobile/src/main/kotlin/dev/marlonlom/mocca/ui/main/MainContent.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/mocca/ui/main/MainContent.kt
@@ -74,7 +74,11 @@ internal fun MainContent(
                   action.gotoDetail(AppDestination.Calculating(amountText))
                 }
               },
-              onHistoryButtonClicked = {},
+              onHistoryButtonClicked = {
+                scope.launch {
+                  action.gotoDetail(AppDestination.History)
+                }
+              },
               onRatesButtonClicked = {},
               onSettingsButtonClicked = {
                 scope.launch {
@@ -89,31 +93,7 @@ internal fun MainContent(
             detailPaneContent = { scaffoldAction ->
               val currentDestination = scaffoldAction.currentDestination
               when (currentDestination) {
-                is AppDestination.Calculating -> {
-                  CalculatorOutputScreen(
-                    mobileWindowSize = scaffoldAction.mobileWindowSize,
-                    requestedAmount = currentDestination.amountText,
-                    onCloseButtonClicked = {
-                      coroutineScope.launch {
-                        scaffoldAction.goBack()
-                      }
-                    },
-                  )
-                }
-
-                AppDestination.History -> {}
-
-                AppDestination.Settings -> {
-                  SettingsRoute(
-                    windowSizeInfo = windowSizeInfo,
-                    mainActions = mainActions,
-                    onBackNavigationAction = {
-                      coroutineScope.launch { scaffoldAction.goBack() }
-                    },
-                  )
-                }
-
-                else -> {
+                AppDestination.History -> {
                   Box(
                     modifier = Modifier
                       .fillMaxSize()
@@ -126,6 +106,40 @@ internal fun MainContent(
                       color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                   }
+                }
+
+                AppDestination.Settings -> {
+                  SettingsRoute(
+                    windowSizeInfo = windowSizeInfo,
+                    mainActions = mainActions,
+                    onBackNavigationAction = {
+                      coroutineScope.launch { scaffoldAction.goBack() }
+                    },
+                  )
+                }
+
+                is AppDestination.Calculating -> {
+                  CalculatorOutputScreen(
+                    mobileWindowSize = scaffoldAction.mobileWindowSize,
+                    requestedAmount = currentDestination.amountText,
+                    onCloseButtonClicked = {
+                      coroutineScope.launch {
+                        scaffoldAction.goBack()
+                      }
+                    },
+                  )
+                }
+
+                else -> {
+                  CalculatorOutputScreen(
+                    mobileWindowSize = scaffoldAction.mobileWindowSize,
+                    requestedAmount = "",
+                    onCloseButtonClicked = {
+                      coroutineScope.launch {
+                        scaffoldAction.goBack()
+                      }
+                    },
+                  )
                 }
               }
             },

--- a/features/mobile/calculator-output/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/output/CalculatorOutputScreen.kt
+++ b/features/mobile/calculator-output/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/output/CalculatorOutputScreen.kt
@@ -44,12 +44,18 @@ fun CalculatorOutputScreen(
   when (mobileWindowSize) {
     MobileWindowSize.MOBILE_LANDSCAPE -> LandscapeCalculatorOutput(
       calculationState = calculationState,
-      onCloseButtonClicked = onCloseButtonClicked,
+      onCloseButtonClicked = {
+        viewModel.onReset()
+        onCloseButtonClicked()
+      },
     )
 
     else -> PortraitCalculatorOutput(
       calculationState = calculationState,
-      onCloseButtonClicked = onCloseButtonClicked,
+      onCloseButtonClicked = {
+        viewModel.onReset()
+        onCloseButtonClicked()
+      },
     )
   }
 }

--- a/features/mobile/calculator-output/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/output/domain/CalculatorOutputViewModel.kt
+++ b/features/mobile/calculator-output/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/output/domain/CalculatorOutputViewModel.kt
@@ -41,7 +41,10 @@ class CalculatorOutputViewModel(
     key = UI_STATE_KEY,
     initialValue = NO_AMOUNT,
   ).map { amountText ->
-    when (val orderResponse = doCalculation(amountText.toDouble())) {
+    if (amountText.isEmpty()) {
+      return@map CalculatorOutputState.Empty
+    }
+    return@map when (val orderResponse = doCalculation(amountText.toDouble())) {
       is OrderResponse.Success<CalculationResult> -> CalculatorOutputState.WithSuccess(
         amount = amountText,
         response = orderResponse.item,


### PR DESCRIPTION
# Pull request detail
Improve navigation handling and empty state behavior in calculator output screen

## Commits
- refactor(mobile:calculator-output): adjust back navigation handle, adjust ui state value when amount value is empty.
- refactor(apps:mobile): adjust main content navigation behaviour.