### PR TITLE
Hotfix/repair version catalogs

### DIFF
--- a/apps/mobile/src/main/kotlin/dev/marlonlom/mocca/ui/main/MainContent.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/mocca/ui/main/MainContent.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
+import com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity
 import dev.marlonlom.mocca.mobile.calculator.history.CalculatorHistoryScreen
 import dev.marlonlom.mocca.mobile.calculator.input.CalculatorInputScreen
 import dev.marlonlom.mocca.mobile.calculator.output.CalculatorOutputScreen
@@ -121,6 +121,7 @@ internal fun MainContent(mainUiState: MainUiState, onOnboarded: () -> Unit) = Mo
                     actions = SettingActions(
                       onOssLicencesDisplayed = {
                         Log.d("MainContent", "Opening oss licenses window")
+                        OssLicensesMenuActivity.setActivityTitle("Legal Notices")
                         currentCtx.startActivity(
                           Intent(currentCtx, OssLicensesMenuActivity::class.java),
                         )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@
 # Infrastructure & Tooling
 agp = "9.2.0"
 kotlin = "2.3.21"
-ksp = "2.3.6"
+ksp = "2.3.7"
 spotless = "8.4.0"
 
 # AndroidX Core & UI
@@ -32,8 +32,8 @@ wearos-compose = "1.6.1"
 
 # Koin & Third Party
 koin-bom = "4.2.1"
-oss-plugin = "0.10.9"
-oss-services = "17.5.0"
+oss-plugin = "0.11.0"
+oss-services = "17.5.1"
 google-play-wearable = "19.0.0"
 
 # Testing & Benchmark


### PR DESCRIPTION
## 🔄 Dependency & OSS Licenses Update

### Summary
This PR updates several dependencies in the project and migrates the OSS Licenses integration to the v2 API, along with a small UX improvement for the licenses screen.

## 📦 Dependency Updates

### Gradle version catalog (`libs.versions.toml`)
- `ksp`: 2.3.6 → 2.3.7  
- `oss-plugin`: 0.10.9 → 0.11.0  
- `oss-services`: 17.5.0 → 17.5.1  

These updates include minor fixes and improvements across tooling and OSS-related services.

## 📄 OSS Licenses Migration

### Migration details
- Updated import:
  - From `com.google.android.gms.oss.licenses.OssLicensesMenuActivity`
  - To `com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity`

### UX improvement
- Set a custom title for the OSS licenses screen: **"Legal Notices"**

```kotlin
OssLicensesMenuActivity.setActivityTitle("Legal Notices")
```

## 🚀 Benefits
- Aligns with the latest OSS Licenses API (v2).
- Ensures compatibility with future Google Play services updates.
- Improves clarity of the legal notices screen
- Keeps dependencies up to date

## ⚠️ Notes
- No changes to core app behavior
- Pure dependency upgrade and minor UI metadata improvement
