### PR TITLE
feat: localize oss licenses and polish calculation history UI

### DIFF
--- a/apps/mobile/src/main/kotlin/dev/marlonlom/mocca/ui/main/MainContent.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/mocca/ui/main/MainContent.kt
@@ -20,7 +20,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity
+import dev.marlonlom.mocca.R
 import dev.marlonlom.mocca.mobile.calculator.history.CalculatorHistoryScreen
 import dev.marlonlom.mocca.mobile.calculator.input.CalculatorInputScreen
 import dev.marlonlom.mocca.mobile.calculator.output.CalculatorOutputScreen
@@ -110,6 +112,7 @@ internal fun MainContent(mainUiState: MainUiState, onOnboarded: () -> Unit) = Mo
 
                 AppDestination.Settings -> {
                   val currentCtx = LocalContext.current
+                  val currentRes = LocalResources.current
                   SettingsScreen(
                     mobileWindowSize = scaffoldAction.mobileWindowSize,
                     showCloseButton = scaffoldAction.arePrimarySecondaryPanesExpanded().not(),
@@ -121,7 +124,9 @@ internal fun MainContent(mainUiState: MainUiState, onOnboarded: () -> Unit) = Mo
                     actions = SettingActions(
                       onOssLicencesDisplayed = {
                         Log.d("MainContent", "Opening oss licenses window")
-                        OssLicensesMenuActivity.setActivityTitle("Legal Notices")
+                        OssLicensesMenuActivity.setActivityTitle(
+                          currentRes.getString(R.string.text_open_source_licenses),
+                        )
                         currentCtx.startActivity(
                           Intent(currentCtx, OssLicensesMenuActivity::class.java),
                         )

--- a/apps/mobile/src/main/res/values-es/strings.xml
+++ b/apps/mobile/src/main/res/values-es/strings.xml
@@ -5,6 +5,5 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 <resources>
-  <string name="app_name" translatable="false">Mocca</string>
-  <string name="text_open_source_licenses">Open source licenses</string>
+  <string name="text_open_source_licenses">Licencias de código abierto</string>
 </resources>

--- a/features/mobile/calculator-history/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/history/component/CalculationHistoryItem.kt
+++ b/features/mobile/calculator-history/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/history/component/CalculationHistoryItem.kt
@@ -6,6 +6,7 @@ package dev.marlonlom.mocca.mobile.calculator.history.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -89,17 +90,7 @@ internal fun CalculationHistoryItem(
           .fillMaxWidth()
           .padding(horizontal = 20.dp),
       ) {
-        HorizontalDivider(
-          modifier = modifier.padding(bottom = 4.dp),
-          thickness = 1.dp,
-          color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f),
-        )
-        Text(
-          modifier = Modifier.fillMaxWidth(),
-          maxLines = 1,
-          style = MaterialTheme.typography.labelSmall,
-          text = domainItem.formattedCreationDate(),
-        )
+        DateWithLine(domainItem.formattedCreationDate(), Modifier)
         Text(
           modifier = Modifier
             .fillMaxWidth()
@@ -108,6 +99,7 @@ internal fun CalculationHistoryItem(
           style = MaterialTheme.typography.labelMedium,
           textAlign = TextAlign.End,
           maxLines = 1,
+          color = MaterialTheme.colorScheme.onBackground,
           text = stringResource(
             R.string.text_amount_with_fee,
             domainItem.amount,
@@ -119,6 +111,7 @@ internal fun CalculationHistoryItem(
             .fillMaxWidth()
             .padding(bottom = 8.dp),
           style = MaterialTheme.typography.displaySmall,
+          color = MaterialTheme.colorScheme.onBackground,
           fontWeight = FontWeight.Bold,
           textAlign = TextAlign.End,
           maxLines = 1,
@@ -129,5 +122,32 @@ internal fun CalculationHistoryItem(
         )
       }
     },
+  )
+}
+
+/**
+ * Composable that shows a date/time label with a trailing horizontal line
+ * expanding to fill the remaining width.
+ *
+ * @param text The date/time text to display.
+ * @param modifier Optional [Modifier] for styling and layout.
+ */
+@Composable
+private fun DateWithLine(text: String, modifier: Modifier = Modifier) = Row(
+  modifier = modifier.fillMaxWidth(),
+  verticalAlignment = Alignment.CenterVertically,
+) {
+  Text(
+    modifier = Modifier.padding(end = 8.dp),
+    maxLines = 1,
+    style = MaterialTheme.typography.labelSmall,
+    color = MaterialTheme.colorScheme.onBackground,
+    text = text,
+  )
+
+  HorizontalDivider(
+    modifier = Modifier.weight(1f),
+    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f),
+    thickness = 1.dp,
   )
 }

--- a/features/mobile/calculator-history/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/history/domain/SuccessfulCalculationDomainData.kt
+++ b/features/mobile/calculator-history/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/history/domain/SuccessfulCalculationDomainData.kt
@@ -46,16 +46,22 @@ data class SuccessfulCalculationDomainData(
    * - If the date is today, returns only the time (`HH:mm`).
    * - Otherwise, returns day, abbreviated month, and time (`dd MMM, HH:mm`).
    *
-   * @param locale Locale to use for month names. Defaults to [Locale.US].
+   * @param locale Locale to use for month names. Defaults to [Locale.getDefault].
    * @return Formatted date string.
    */
   fun formattedCreationDate(locale: Locale = Locale.getDefault()): String {
     val calendar = Calendar.getInstance(TimeZone.getDefault())
     calendar.time = createdAt
-    val today = Calendar.getInstance(TimeZone.getDefault())
+    val today = Calendar.getInstance(locale)
     val isToday = calendar.get(Calendar.YEAR) == today.get(Calendar.YEAR) &&
       calendar.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR)
-    val pattern = if (isToday) "HH:mm" else "dd MMM, HH:mm"
+    val isSameYear = calendar.get(Calendar.YEAR) == today.get(Calendar.YEAR) &&
+      calendar.get(Calendar.DAY_OF_YEAR) != today.get(Calendar.DAY_OF_YEAR)
+    val pattern = when {
+      isToday -> "HH:mm"
+      isSameYear -> "dd MMM, HH:mm"
+      else -> "dd MMM ''yy, HH:mm"
+    }
     val formatter = SimpleDateFormat(pattern, locale).apply {
       timeZone = TimeZone.getDefault()
     }


### PR DESCRIPTION
# Description

This PR improves application localization, refactors the calculation history item UI for better responsiveness, and fixes an edge case in historical date formatting.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (cleaner code, no functional UI changes)

## Changes Implemented

### 🌐 Localization & Resources
- Removed the hardcoded `"Legal Notices"` string when launching `OssLicensesMenuActivity`.
- Added localized string assets (`text_open_source_licenses`) for both default (English) and Spanish (`values-es/strings.xml`) configurations.
- Switch implementation to rely on context-safe resource lookups.

### 🎨 UI Refactoring (`CalculationHistoryItem.kt`)
- Extracted the date text and divider logic into a private, reusable `@Composable` component named `DateWithLine`.
- Replaced the hardcoded vertical-stack layout with a dynamic `Row` layout utilizing `Modifier.weight(1f)` on the `HorizontalDivider` so it correctly scales across varying screen widths.
- Explicitly defined `MaterialTheme.colorScheme.onBackground` colors on textual components to avoid dark/light mode parsing issues.

### 📅 Date & Time Logic (`SuccessfulCalculationDomainData.kt`)
- Fixed a bug where past-year calculations were not visually distinct. Added an `else` branch tracking fallback conditions for dates older than the current calendar year (`dd MMM ''yy, HH:mm`).
- Refactored `Calendar.getInstance` parameters to leverage the explicit `locale` configuration rather than defaulting purely to timezone configurations.

## Testing Checklist

- [x] Validated localization switching between English and Spanish on a physical device/emulator.
- [x] Confirmed the OSS Licenses page title updates dynamically matching the system language configuration.
- [x] Verified that old calculation items from prior years correctly render with the abbreviated two-digit year suffix (`'yy`).
- [x] Inspected the history item layout to ensure the divider fills remaining space cleanly without layout breakage.