### PR TITLE
# feat(mobile:calculator-fees): integrate calculator-fees module into mobile app

### DIFF
--- a/apps/mobile/build.gradle.kts
+++ b/apps/mobile/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation(project(":features:core:calculator"))
   implementation(project(":features:core:database"))
   implementation(project(":features:core:preferences"))
+  implementation(project(":features:mobile:calculator-fees"))
   implementation(project(":features:mobile:calculator-history"))
   implementation(project(":features:mobile:calculator-input"))
   implementation(project(":features:mobile:calculator-output"))

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/mocca/di/AppKoinModule.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/mocca/di/AppKoinModule.kt
@@ -6,6 +6,7 @@ package dev.marlonlom.mocca.di
 
 import dev.marlonlom.mocca.core.database.di.databaseKoinModule
 import dev.marlonlom.mocca.core.preferences.di.preferencesKoinModule
+import dev.marlonlom.mocca.mobile.calculator.fees.di.calculatorFeesKoinModule
 import dev.marlonlom.mocca.mobile.calculator.history.di.calculatorHistoryKoinModule
 import dev.marlonlom.mocca.mobile.calculator.input.di.calculatorInputKoinModule
 import dev.marlonlom.mocca.mobile.calculator.output.di.calculatorOutputKoinModule
@@ -25,6 +26,7 @@ val appKoinModule = module {
   includes(calculatorInputKoinModule)
   includes(calculatorOutputKoinModule)
   includes(calculatorHistoryKoinModule)
+  includes(calculatorFeesKoinModule)
   includes(settingsMobileKoinModule)
   viewModelOf(::MainViewModel)
 }

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/mocca/ui/main/MainContent.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/mocca/ui/main/MainContent.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity
 import dev.marlonlom.mocca.R
+import dev.marlonlom.mocca.mobile.calculator.fees.CalculatorFeesScreen
 import dev.marlonlom.mocca.mobile.calculator.history.CalculatorHistoryScreen
 import dev.marlonlom.mocca.mobile.calculator.input.CalculatorInputScreen
 import dev.marlonlom.mocca.mobile.calculator.output.CalculatorOutputScreen
@@ -85,7 +86,11 @@ internal fun MainContent(mainUiState: MainUiState, onOnboarded: () -> Unit) = Mo
                   action.gotoDetail(AppDestination.History)
                 }
               },
-              onRatesButtonClicked = {},
+              onRatesButtonClicked = {
+                scope.launch {
+                  action.gotoDetail(AppDestination.Fees)
+                }
+              },
               onSettingsButtonClicked = {
                 scope.launch {
                   action.gotoDetail(AppDestination.Settings)
@@ -98,6 +103,18 @@ internal fun MainContent(mainUiState: MainUiState, onOnboarded: () -> Unit) = Mo
             listPaneContent = { scaffoldAction -> listPane(coroutineScope, scaffoldAction) },
             detailPaneContent = { scaffoldAction ->
               when (val currentDestination = scaffoldAction.currentDestination) {
+                AppDestination.Fees -> {
+                  CalculatorFeesScreen(
+                    mobileWindowSize = scaffoldAction.mobileWindowSize,
+                    showCloseButton = scaffoldAction.arePrimarySecondaryPanesExpanded().not(),
+                    onCloseButtonClicked = {
+                      coroutineScope.launch {
+                        scaffoldAction.goBack()
+                      }
+                    },
+                  )
+                }
+
                 AppDestination.History -> {
                   CalculatorHistoryScreen(
                     mobileWindowSize = scaffoldAction.mobileWindowSize,

--- a/features/core/calculator/src/main/kotlin/dev/marlonlom/mocca/calculator/Calculator.kt
+++ b/features/core/calculator/src/main/kotlin/dev/marlonlom/mocca/calculator/Calculator.kt
@@ -9,6 +9,7 @@ import dev.marlonlom.mocca.calculator.model.CalculationException.BelowQuantityRa
 import dev.marlonlom.mocca.calculator.model.CalculationException.NegativeQuantity
 import dev.marlonlom.mocca.calculator.model.OrderFees
 import dev.marlonlom.mocca.calculator.model.OrderResponse
+import dev.marlonlom.mocca.calculator.util.UsedNumbers
 import dev.marlonlom.mocca.calculator.util.UsedNumbers.MAX_VALUE
 import dev.marlonlom.mocca.calculator.util.UsedNumbers.MIN_VALUE
 import dev.marlonlom.mocca.calculator.util.UsedNumbers.ZERO
@@ -41,6 +42,9 @@ object Calculator {
   private fun orderValueIsInsideRange(request: RequestedQuantity) = request.orderValue.let {
     min(MIN_VALUE, it) == MIN_VALUE && max(MAX_VALUE, it) == MAX_VALUE
   }
+
+  /** Variable fee factor. */
+  const val VARIABLE_FEE_FACTOR: Double = UsedNumbers.FOUR
 
   /**
    * Returns the valid range for calculator input amounts.

--- a/features/core/calculator/src/main/kotlin/dev/marlonlom/mocca/calculator/util/UsedNumbers.kt
+++ b/features/core/calculator/src/main/kotlin/dev/marlonlom/mocca/calculator/util/UsedNumbers.kt
@@ -12,7 +12,7 @@ package dev.marlonlom.mocca.calculator.util
 internal object UsedNumbers {
   const val ZERO = 0.0
   const val ONE = 1.0
-  private const val FOUR = 4.0
+  const val FOUR = 4.0
   const val ONE_HUNDRED = 100
 
   const val MIN_VALUE = 5_000.0

--- a/features/mobile/calculator-fees/build.gradle.kts
+++ b/features/mobile/calculator-fees/build.gradle.kts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+  id("mocca.android.lib.mobile")
+  id("mocca.compose.lib")
+}
+
+android {
+  namespace = "dev.marlonlom.mocca.mobile.calculator.fees"
+}
+
+dependencies {
+  implementation(project(":features:core:calculator"))
+  implementation(project(":features:core:ui"))
+  implementation(project(":features:mobile:ui"))
+  implementation(libs.androidx.compose.material3)
+  implementation(libs.androidx.compose.material3.wsc)
+  implementation(libs.bundles.m3.adaptive)
+}

--- a/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/CalculatorFeesScreen.kt
+++ b/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/CalculatorFeesScreen.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.mobile.calculator.fees
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.marlonlom.mocca.mobile.calculator.fees.domain.CalculatorFeesUiState
+import dev.marlonlom.mocca.mobile.calculator.fees.domain.CalculatorFeesViewModel
+import dev.marlonlom.mocca.mobile.calculator.fees.layout.PortraitHistory
+import dev.marlonlom.mocca.mobile.ui.window.MobileWindowSize
+import org.koin.androidx.compose.koinViewModel
+
+/**
+ * A screen that displays a list of previous calculations.
+ *
+ * @author marlonlom
+ *
+ * @param mobileWindowSize The adaptive layout size used to adjust UI spacing.
+ * @param showCloseButton Toggles the visibility of the exit icon.
+ * @param onCloseButtonClicked Callback invoked when the user exits the history view.
+ * @param viewModel The state holder for history data, defaulted via Koin.
+ */
+@Composable
+fun CalculatorFeesScreen(
+  mobileWindowSize: MobileWindowSize,
+  showCloseButton: Boolean,
+  onCloseButtonClicked: () -> Unit,
+  viewModel: CalculatorFeesViewModel = koinViewModel(),
+) {
+  val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+  val domainData = (uiState as? CalculatorFeesUiState.Success)?.fees.orEmpty()
+  PortraitHistory(
+    feesData = { domainData },
+    mobileWindowSize = mobileWindowSize,
+    showCloseButton = showCloseButton,
+    onCloseButtonClicked = onCloseButtonClicked,
+  )
+}

--- a/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/component/CalculationFeeListItem.kt
+++ b/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/component/CalculationFeeListItem.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.mobile.calculator.fees.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import dev.marlonlom.mocca.mobile.calculator.fees.R
+import dev.marlonlom.mocca.mobile.calculator.fees.domain.SuccessfulFeesDomainData
+
+/**
+ * A single row representing a calculation fee entry.
+ *
+ * @author marlonlom
+ *
+ * @param itemPosition The position of the calculation fee item in the list.
+ * @param domainItem The data model containing calculation fee details.
+ * @param modifier Standard Compose modifier for layout adjustments.
+ */
+@Composable
+internal fun CalculationFeeListItem(
+  itemPosition: Int,
+  domainItem: SuccessfulFeesDomainData,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 20.dp),
+  ) {
+    DateWithLine("#${itemPosition.plus(1)}", Modifier)
+    println(domainItem)
+    Text(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(vertical = 8.dp),
+      fontStyle = FontStyle.Italic,
+      style = MaterialTheme.typography.labelMedium,
+      textAlign = TextAlign.End,
+      maxLines = 1,
+      color = MaterialTheme.colorScheme.onBackground,
+      text = stringResource(
+        R.string.text_price_range,
+        domainItem.min,
+        domainItem.max,
+      ),
+    )
+    Text(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(bottom = 8.dp),
+      style = MaterialTheme.typography.displaySmall,
+      color = MaterialTheme.colorScheme.onBackground,
+      fontWeight = FontWeight.Bold,
+      textAlign = TextAlign.End,
+      maxLines = 1,
+      text = if (domainItem.haveVariableFee) {
+        stringResource(
+          R.string.text_fee_percentage,
+          domainItem.variableFeeFactor,
+        )
+      } else {
+        stringResource(
+          R.string.text_fee_amount,
+          domainItem.fixedFee,
+        )
+      },
+    )
+  }
+}
+
+/**
+ * Composable that shows a date/time label with a trailing horizontal line
+ * expanding to fill the remaining width.
+ *
+ * @param text The date/time text to display.
+ * @param modifier Optional [Modifier] for styling and layout.
+ */
+@Composable
+private fun DateWithLine(text: String, modifier: Modifier = Modifier) = Row(
+  modifier = modifier.fillMaxWidth(),
+  verticalAlignment = Alignment.CenterVertically,
+) {
+  Text(
+    modifier = Modifier.padding(end = 8.dp),
+    maxLines = 1,
+    style = MaterialTheme.typography.labelSmall,
+    color = MaterialTheme.colorScheme.onBackground,
+    text = text,
+  )
+
+  HorizontalDivider(
+    modifier = Modifier.weight(1f),
+    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f),
+    thickness = 1.dp,
+  )
+}

--- a/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/component/EmptyCalculationFees.kt
+++ b/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/component/EmptyCalculationFees.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.mobile.calculator.fees.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import dev.marlonlom.mocca.mobile.calculator.fees.R
+
+/**
+ * Empty state shown when there are no calculation fees records.
+ *
+ * @author marlonlom
+ *
+ */
+@Composable
+internal fun EmptyCalculationFees() = Column(
+  modifier = Modifier
+    .fillMaxHeight()
+    .background(MaterialTheme.colorScheme.surface),
+  horizontalAlignment = Alignment.CenterHorizontally,
+) {
+  HorizontalDivider(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(bottom = 4.dp),
+    thickness = 1.dp,
+    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f),
+  )
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Column {
+      Text(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(bottom = 4.dp),
+        color = MaterialTheme.colorScheme.onSurface,
+        style = MaterialTheme.typography.titleLarge,
+        fontWeight = FontWeight.Bold,
+        textAlign = TextAlign.Center,
+        maxLines = 1,
+        text = stringResource(R.string.text_empty_fees_title),
+      )
+      Text(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(bottom = 10.dp),
+        color = MaterialTheme.colorScheme.onSurface,
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.Normal,
+        textAlign = TextAlign.Center,
+        text = stringResource(R.string.text_empty_fees_detail),
+      )
+    }
+  }
+}

--- a/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/di/CalculationFeesKoinModule.kt
+++ b/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/di/CalculationFeesKoinModule.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.mobile.calculator.fees.di
+
+import dev.marlonlom.mocca.calculator.Calculator
+import dev.marlonlom.mocca.calculator.model.OrderFees
+import dev.marlonlom.mocca.mobile.calculator.fees.domain.CalculatorFeesViewModel
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+/**
+ * Calculator fees mobile ui Koin module.
+ *
+ * @author marlonlom
+ */
+val calculatorFeesKoinModule = module {
+  single<CalculatorFeesViewModel> {
+    CalculatorFeesViewModel(
+      calculatorFees = {
+        OrderFees.entries.toList()
+      },
+      calculatorVariableFeeFactor = {
+        Calculator.VARIABLE_FEE_FACTOR
+      },
+    )
+  } bind CalculatorFeesViewModel::class
+}

--- a/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/domain/CalculatorFeesUiState.kt
+++ b/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/domain/CalculatorFeesUiState.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.mobile.calculator.fees.domain
+
+/**
+ * Represents the various states of the Calculation fees UI.
+ *
+ * @author marlonlom
+ */
+sealed interface CalculatorFeesUiState {
+
+  /**
+   * Represents the state where the fees data is empty.
+   *
+   * @author marlonlom
+   */
+  data object Empty : CalculatorFeesUiState
+
+  /**
+   * Represents the state where the fees data have been successfully loaded.
+   *
+   * @author marlonlom
+   *
+   * @property fees Calculation fees data from data layer.
+   */
+  data class Success(val fees: List<SuccessfulFeesDomainData>) : CalculatorFeesUiState
+}

--- a/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/domain/CalculatorFeesViewModel.kt
+++ b/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/domain/CalculatorFeesViewModel.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.mobile.calculator.fees.domain
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.marlonlom.mocca.calculator.model.OrderFees
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * ViewModel responsible for managing and exposing calculator fees UI state.
+ *
+ * @author marlonlom
+ *
+ * @property calculatorFees Function to retrieve a list of order fees.
+ * @property calculatorVariableFeeFactor Function to retrieve the variable fee factor.
+ *
+ */
+class CalculatorFeesViewModel(
+  private val calculatorFees: () -> List<OrderFees>,
+  private val calculatorVariableFeeFactor: () -> Double,
+) : ViewModel() {
+
+  /**
+   * Represents the UI state of the settings screen.
+   *
+   * It emits [CalculatorFeesUiState.Success] with the current settings,
+   * or [CalculatorFeesUiState.Empty] while initially loading.
+   *
+   */
+  val uiState: StateFlow<CalculatorFeesUiState> = flowOf(obtainCalculationFees()).stateIn(
+    scope = viewModelScope,
+    started = SharingStarted.WhileSubscribed(5000L),
+    initialValue = CalculatorFeesUiState.Empty,
+  )
+
+  /**
+   * Maps a list of [OrderFees] to a corresponding [CalculatorFeesUiState].
+   *
+   * Returns [CalculatorFeesUiState.Empty] if the list is empty,
+   * otherwise returns [CalculatorFeesUiState.Success] with mapped domain items.
+   *
+   * @return [CalculatorFeesUiState] representing the UI state.
+   */
+  private fun obtainCalculationFees(): CalculatorFeesUiState = calculatorFees().let {
+    if (it.isEmpty()) return CalculatorFeesUiState.Empty
+    CalculatorFeesUiState.Success(
+      fees = it.map { fee ->
+        SuccessfulFeesDomainData(
+          min = fee.min,
+          max = fee.max,
+          fixedFee = fee.fixedFee,
+          haveVariableFee = fee.haveVariableFee,
+          variableFeeFactor = if (fee.haveVariableFee) calculatorVariableFeeFactor() else 0.0,
+        )
+      },
+    )
+  }
+}

--- a/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/domain/SuccessfulFeesDomainData.kt
+++ b/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/domain/SuccessfulFeesDomainData.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.mobile.calculator.fees.domain
+
+/**
+ * Represents the result of a successful calculation in the domain layer.
+ *
+ * @author marlonlom
+ *
+ * @property min Minimum value for the fee range.
+ * @property max Maximum value for the fee range.
+ * @property fixedFee Fixed fee value.
+ * @property haveVariableFee Indicates if variable fee is included.
+ * @property variableFeeFactor Variable fee factor value.
+ *
+ */
+data class SuccessfulFeesDomainData(
+  val min: Double,
+  val max: Double,
+  val fixedFee: Double,
+  val haveVariableFee: Boolean,
+  val variableFeeFactor: Double,
+)

--- a/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/layout/PortraitHistory.kt
+++ b/features/mobile/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/layout/PortraitHistory.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.mobile.calculator.fees.layout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.marlonlom.mocca.mobile.calculator.fees.component.CalculationFeeListItem
+import dev.marlonlom.mocca.mobile.calculator.fees.component.EmptyCalculationFees
+import dev.marlonlom.mocca.mobile.calculator.fees.domain.SuccessfulFeesDomainData
+import dev.marlonlom.mocca.mobile.ui.component.header.HeaderBar
+import dev.marlonlom.mocca.mobile.ui.component.iconbutton.ExitIconButton
+import dev.marlonlom.mocca.mobile.ui.window.MobileWindowSize
+import dev.marlonlom.mocca.mobile.ui.R as mobileUiR
+
+/**
+ * Displays the calculator fees list in portrait mode.
+ *
+ * @author marlonlom
+ *
+ * @param feesData Lambda providing the list of calculation fee items.
+ * @param mobileWindowSize Current mobile window size to adjust layout.
+ * @param showCloseButton Whether to show the close button.
+ * @param onCloseButtonClicked Callback invoked when the close button is clicked.
+ */
+@Composable
+internal fun PortraitHistory(
+  feesData: () -> List<SuccessfulFeesDomainData>,
+  mobileWindowSize: MobileWindowSize,
+  showCloseButton: Boolean,
+  onCloseButtonClicked: () -> Unit,
+) = Column(
+  modifier = Modifier
+    .background(MaterialTheme.colorScheme.background)
+    .padding(horizontal = 20.dp)
+    .consumeWindowInsets(WindowInsets.systemBars),
+  horizontalAlignment = Alignment.CenterHorizontally,
+) {
+  HeaderBar(title = {
+    Text(
+      text = stringResource(mobileUiR.string.text_fees),
+      overflow = TextOverflow.Ellipsis,
+      maxLines = 1,
+    )
+  }, isMedium = mobileWindowSize != MobileWindowSize.MOBILE_LANDSCAPE, navigationIcon = {
+    if (showCloseButton) {
+      ExitIconButton(onButtonClicked = onCloseButtonClicked)
+    }
+  })
+  val data = feesData()
+  when {
+    data.isEmpty() -> {
+      EmptyCalculationFees()
+    }
+
+    else -> {
+      LazyColumn(
+        modifier = Modifier.then(
+          when (mobileWindowSize) {
+            MobileWindowSize.MOBILE_LANDSCAPE -> Modifier.widthIn(max = 640.dp)
+            else -> Modifier.fillMaxWidth()
+          },
+        ),
+      ) {
+        itemsIndexed(
+          items = data,
+        ) { position, item ->
+          CalculationFeeListItem(
+            itemPosition = position,
+            domainItem = item,
+          )
+        }
+
+        item {
+          Spacer(Modifier.height(16.dp))
+        }
+      }
+    }
+  }
+}

--- a/features/mobile/calculator-fees/src/main/res/values-es/strings.xml
+++ b/features/mobile/calculator-fees/src/main/res/values-es/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2024 Marlonlom
+  SPDX-License-Identifier: Apache-2.0
+-->
+<resources>
+  <string name="text_price_range">Entre $%1$,.0f y $%2$,.0f</string>
+  <string name="text_fee_percentage">%1$.0f%% del valor</string>
+  <string name="text_empty_fees_title">Sin tarifas disponibles</string>
+  <string name="text_empty_fees_detail">No hay tarifas registradas en este momento.</string>
+</resources>

--- a/features/mobile/calculator-fees/src/main/res/values/strings.xml
+++ b/features/mobile/calculator-fees/src/main/res/values/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2024 Marlonlom
+  SPDX-License-Identifier: Apache-2.0
+-->
+<resources>
+  <string name="text_fee_amount" translatable="false">$%1$,.0f</string>
+  <string name="text_price_range">Between $%1$,.0f and $%2$,.0f</string>
+  <string name="text_fee_percentage">%1$.0f%% of the value</string>
+  <string name="text_empty_fees_title">No rates available</string>
+  <string name="text_empty_fees_detail">There are no rates registered at the moment.</string>
+</resources>

--- a/features/mobile/calculator-fees/src/test/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/domain/CalculatorFeesViewModelTest.kt
+++ b/features/mobile/calculator-fees/src/test/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/domain/CalculatorFeesViewModelTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.mobile.calculator.fees.domain
+
+import dev.marlonlom.mocca.calculator.model.OrderFees
+import dev.marlonlom.mocca.mobile.calculator.fees.util.MainDispatcherRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class CalculatorFeesViewModelTest {
+
+  @get:Rule
+  val mainDispatcherRule = MainDispatcherRule()
+
+  private val calculatorFees = mockk<() -> List<OrderFees>>()
+  private val calculatorVariableFeeFactor = mockk<() -> Double>()
+
+  @Test
+  fun `uiState should be Empty when no fees exist`() = runTest {
+    every { calculatorFees.invoke() } returns emptyList()
+
+    val viewModel = CalculatorFeesViewModel(
+      calculatorFees = calculatorFees,
+      calculatorVariableFeeFactor = calculatorVariableFeeFactor,
+    )
+
+    val result = viewModel.uiState.first()
+
+    assertEquals(CalculatorFeesUiState.Empty, result)
+
+    verify(exactly = 1) { calculatorFees.invoke() }
+    verify(exactly = 0) { calculatorVariableFeeFactor.invoke() }
+  }
+
+  @Test
+  fun `uiState should map variable fee factor when fee supports variable fee`() = runTest {
+    val fee = OrderFees.FIFTH_FEE
+
+    every { calculatorFees.invoke() } returns listOf(fee)
+    every { calculatorVariableFeeFactor.invoke() } returns 2.5
+
+    val viewModel = CalculatorFeesViewModel(
+      calculatorFees = calculatorFees,
+      calculatorVariableFeeFactor = calculatorVariableFeeFactor,
+    )
+
+    val result = viewModel.uiState.first()
+
+    assertEquals(
+      CalculatorFeesUiState.Success(
+        fees = listOf(
+          SuccessfulFeesDomainData(
+            min = fee.min,
+            max = fee.max,
+            fixedFee = fee.fixedFee,
+            haveVariableFee = fee.haveVariableFee,
+            variableFeeFactor = 2.5,
+          ),
+        ),
+      ),
+      result,
+    )
+
+    verify(exactly = 1) { calculatorVariableFeeFactor.invoke() }
+  }
+
+  @Test
+  fun `uiState should set variable fee factor to zero when fee does not support variable fee`() = runTest {
+    val fee = OrderFees.FIRST_FEE
+
+    every { calculatorFees.invoke() } returns listOf(fee)
+
+    val viewModel = CalculatorFeesViewModel(
+      calculatorFees = calculatorFees,
+      calculatorVariableFeeFactor = calculatorVariableFeeFactor,
+    )
+
+    val result = viewModel.uiState.first()
+
+    assertEquals(
+      CalculatorFeesUiState.Success(
+        fees = listOf(
+          SuccessfulFeesDomainData(
+            min = fee.min,
+            max = fee.max,
+            fixedFee = fee.fixedFee,
+            haveVariableFee = fee.haveVariableFee,
+            variableFeeFactor = 0.0,
+          ),
+        ),
+      ),
+      result,
+    )
+
+    verify(exactly = 0) { calculatorVariableFeeFactor.invoke() }
+  }
+}

--- a/features/mobile/calculator-fees/src/test/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/util/MainDispatcherRule.kt
+++ b/features/mobile/calculator-fees/src/test/kotlin/dev/marlonlom/mocca/mobile/calculator/fees/util/MainDispatcherRule.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.mobile.calculator.fees.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Reusable JUnit4 TestRule to override the Main dispatcher
+ *
+ * @author marlonlom
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class MainDispatcherRule(private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()) :
+  TestWatcher() {
+  override fun starting(description: Description) {
+    Dispatchers.setMain(testDispatcher)
+  }
+
+  override fun finished(description: Description) {
+    Dispatchers.resetMain()
+  }
+}

--- a/features/mobile/calculator-history/src/main/res/values-es/strings.xml
+++ b/features/mobile/calculator-history/src/main/res/values-es/strings.xml
@@ -5,6 +5,7 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 <resources>
+  <string name="text_amount_with_fee">Cantidad: $%1$d + comisión: $%2$d</string>
   <string name="text_clear_history">Limpiar historial</string>
   <string name="text_delete_history">Borrar</string>
   <string name="text_empty_history_title">No hay nada aquí</string>

--- a/features/mobile/calculator-history/src/main/res/values/strings.xml
+++ b/features/mobile/calculator-history/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 <resources>
-  <string name="text_amount_with_fee" translatable="false">Amount: $%1$d + Fee: $%2$d</string>
+  <string name="text_amount_with_fee">Amount: $%1$d + fee: $%2$d</string>
   <string name="text_amount_total" translatable="false">$%1$,d</string>
   <string name="text_clear_history">Clear history</string>
   <string name="text_delete_history">Delete</string>

--- a/features/mobile/calculator-input/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/input/layout/LandscapeCalculatorInput.kt
+++ b/features/mobile/calculator-input/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/input/layout/LandscapeCalculatorInput.kt
@@ -29,8 +29,8 @@ import dev.marlonlom.mocca.mobile.calculator.input.domain.CalculatorAmountUiStat
 import dev.marlonlom.mocca.mobile.calculator.input.slot.CalculatorButtonsGrid
 import dev.marlonlom.mocca.mobile.ui.component.button.WideCalculateButton
 import dev.marlonlom.mocca.mobile.ui.component.header.HeaderBar
+import dev.marlonlom.mocca.mobile.ui.component.iconbutton.FeesIconButton
 import dev.marlonlom.mocca.mobile.ui.component.iconbutton.HistoryIconButton
-import dev.marlonlom.mocca.mobile.ui.component.iconbutton.RatesIconButton
 import dev.marlonlom.mocca.mobile.ui.component.iconbutton.SettingsIconButton
 
 /**
@@ -73,7 +73,7 @@ internal fun LandscapeCalculatorInput(
     isMedium = false,
     navigationActions = {
       HistoryIconButton(onButtonClicked = { onHistoryButtonClicked() })
-      RatesIconButton(onButtonClicked = { onRatesButtonClicked() })
+      FeesIconButton(onButtonClicked = { onRatesButtonClicked() })
       SettingsIconButton(onButtonClicked = { onSettingsButtonClicked() })
     },
   )

--- a/features/mobile/calculator-input/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/input/layout/PortraitCalculatorInput.kt
+++ b/features/mobile/calculator-input/src/main/kotlin/dev/marlonlom/mocca/mobile/calculator/input/layout/PortraitCalculatorInput.kt
@@ -24,8 +24,8 @@ import dev.marlonlom.mocca.mobile.calculator.input.domain.CalculatorAmountUiStat
 import dev.marlonlom.mocca.mobile.calculator.input.slot.CalculatorButtonsGrid
 import dev.marlonlom.mocca.mobile.ui.component.button.WideCalculateButton
 import dev.marlonlom.mocca.mobile.ui.component.header.HeaderBar
+import dev.marlonlom.mocca.mobile.ui.component.iconbutton.FeesIconButton
 import dev.marlonlom.mocca.mobile.ui.component.iconbutton.HistoryIconButton
-import dev.marlonlom.mocca.mobile.ui.component.iconbutton.RatesIconButton
 import dev.marlonlom.mocca.mobile.ui.component.iconbutton.SettingsIconButton
 import dev.marlonlom.mocca.mobile.ui.component.spacer.FullWidthSpacer
 
@@ -68,7 +68,7 @@ internal fun PortraitCalculatorInput(
     isMedium = true,
     navigationActions = {
       HistoryIconButton(onButtonClicked = { onHistoryButtonClicked() })
-      RatesIconButton(onButtonClicked = { onRatesButtonClicked() })
+      FeesIconButton(onButtonClicked = { onRatesButtonClicked() })
       SettingsIconButton(onButtonClicked = { onSettingsButtonClicked() })
     },
   )

--- a/features/mobile/ui/src/main/kotlin/dev/marlonlom/mocca/mobile/ui/component/iconbutton/FeesIconButton.kt
+++ b/features/mobile/ui/src/main/kotlin/dev/marlonlom/mocca/mobile/ui/component/iconbutton/FeesIconButton.kt
@@ -14,17 +14,17 @@ import androidx.compose.ui.res.stringResource
 import dev.marlonlom.mocca.mobile.ui.R
 
 /**
- * A composable function that displays a rates icon button.
+ * A composable function that displays a fees icon button.
  *
  * @author marlonlom
  *
  * @param onButtonClicked Action invoked when the button is clicked.
  */
 @Composable
-fun RatesIconButton(onButtonClicked: () -> Unit) = IconButton(onClick = onButtonClicked) {
+fun FeesIconButton(onButtonClicked: () -> Unit) = IconButton(onClick = onButtonClicked) {
   Icon(
     imageVector = Icons.Rounded.TableChart,
-    contentDescription = stringResource(R.string.text_rates),
+    contentDescription = stringResource(R.string.text_fees),
     tint = MaterialTheme.colorScheme.primary,
   )
 }

--- a/features/mobile/ui/src/main/kotlin/dev/marlonlom/mocca/mobile/ui/navigation/AppDestination.kt
+++ b/features/mobile/ui/src/main/kotlin/dev/marlonlom/mocca/mobile/ui/navigation/AppDestination.kt
@@ -42,12 +42,12 @@ sealed class AppDestination : Parcelable {
   data object History : AppDestination()
 
   /**
-   * Destination representing the Rates screen.
+   * Destination representing the Fees screen.
    *
    * @author marlonlom
    */
   @Parcelize
-  data object Rates : AppDestination()
+  data object Fees : AppDestination()
 
   /**
    * Destination representing the Settings screen.

--- a/features/mobile/ui/src/main/kotlin/dev/marlonlom/mocca/mobile/ui/navigation/AppDestination.kt
+++ b/features/mobile/ui/src/main/kotlin/dev/marlonlom/mocca/mobile/ui/navigation/AppDestination.kt
@@ -42,6 +42,14 @@ sealed class AppDestination : Parcelable {
   data object History : AppDestination()
 
   /**
+   * Destination representing the Rates screen.
+   *
+   * @author marlonlom
+   */
+  @Parcelize
+  data object Rates : AppDestination()
+
+  /**
    * Destination representing the Settings screen.
    *
    * @author marlonlom

--- a/features/mobile/ui/src/main/res/values-es/strings.xml
+++ b/features/mobile/ui/src/main/res/values-es/strings.xml
@@ -7,7 +7,7 @@
 <resources>
   <string name="text_calculate">Calcular</string>
   <string name="text_history">Historial</string>
-  <string name="text_rates">Tarifas</string>
+  <string name="text_fees">Tarifas</string>
   <string name="text_settings">Configuración</string>
   <string name="text_close">Cerrar</string>
   <string name="text_unknown_version">Versión desconocida</string>

--- a/features/mobile/ui/src/main/res/values/strings.xml
+++ b/features/mobile/ui/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
   <string translatable="false" name="url_feedback_website">http://play.google.com/store/apps/details?id=%1$s</string>
   <string name="text_calculate">Calculate</string>
   <string name="text_history">History</string>
-  <string name="text_rates">Rates</string>
+  <string name="text_fees">Fees</string>
   <string name="text_settings">Settings</string>
   <string name="text_close">Close</string>
   <string name="text_unknown_version">Unknown version</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,9 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
@@ -26,3 +28,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+kotlin.daemon.jvm.options=-Xmx2048m

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,7 @@ include(
   ":features:mobile:calculator-input",
   ":features:mobile:calculator-output",
   ":features:mobile:calculator-history",
+  ":features:mobile:calculator-fees",
   ":features:mobile:onboarding",
   ":features:mobile:settings",
   ":features:mobile:ui"


### PR DESCRIPTION
# feat(mobile:calculator-fees): integrate calculator-fees module into mobile app

## Summary

This PR integrates the new **calculator-fees** feature module into the mobile application and completes its end-to-end wiring across dependency injection, navigation, and UI.

## Changes

- Add `:features:mobile:calculator-fees` module dependency
- Include `calculatorFeesKoinModule` in `AppKoinModule`
- Introduce `AppDestination.Fees` navigation target
- Wire navigation action from Fees button to `AppDestination.Fees`
- Add `CalculatorFeesScreen` rendering in `MainContent`
- Ensure proper back navigation handling for Fees screen

## UI / Navigation updates

- Replaces previous "Rates" concept with "Fees"
- Aligns naming across:
  - UI components (`FeesIconButton`)
  - Strings (`text_fees`)
  - Navigation (`AppDestination.Fees`)
  - Feature module (`calculator-fees`)

## Impact

- Adds a new feature entry point in the app
- Improves modularity by isolating fees logic into its own module
- Ensures consistent naming across UI, navigation, and domain layers

## Testing

- Verify navigation from main calculator screen to Fees screen
- Verify Fees screen renders correctly in both portrait and landscape layouts
- Verify back navigation works in split-pane layouts
- Verify Koin module loads without runtime DI errors