### PR TITLE
refactor: centralize Material3 Adaptive dependencies in mobile convention plugin

### DIFF
--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/MobileAndroidLibPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/MobileAndroidLibPlugin.kt
@@ -7,16 +7,22 @@ package dev.marlonlom.mocca.plugins.libs
 
 import com.android.build.api.dsl.LibraryExtension
 import dev.marlonlom.mocca.configs.Config
+import dev.marlonlom.mocca.extensions.versionCatalog
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 
 class MobileAndroidLibPlugin : Plugin<Project> {
 
   override fun apply(project: Project) {
     with(project) {
       pluginManager.apply("mocca.android.lib.common")
-
+      dependencies {
+        add("implementation", versionCatalog().findLibrary("androidx-compose-material3").get())
+        add("implementation", versionCatalog().findLibrary("androidx-compose-material3-wsc").get())
+        add("implementation", versionCatalog().findBundle("m3-adaptive").get())
+      }
       extensions.configure<LibraryExtension> {
         namespace = Config.mobile.nameSpace
         compileSdk = Config.mobile.compileSdkVersion

--- a/features/mobile/calculator-fees/build.gradle.kts
+++ b/features/mobile/calculator-fees/build.gradle.kts
@@ -4,8 +4,8 @@
  */
 
 plugins {
-  id("mocca.android.lib.mobile")
   id("mocca.compose.lib")
+  id("mocca.android.lib.mobile")
 }
 
 android {
@@ -14,9 +14,5 @@ android {
 
 dependencies {
   implementation(project(":features:core:calculator"))
-  implementation(project(":features:core:ui"))
   implementation(project(":features:mobile:ui"))
-  implementation(libs.androidx.compose.material3)
-  implementation(libs.androidx.compose.material3.wsc)
-  implementation(libs.bundles.m3.adaptive)
 }

--- a/features/mobile/calculator-history/build.gradle.kts
+++ b/features/mobile/calculator-history/build.gradle.kts
@@ -15,9 +15,5 @@ android {
 dependencies {
   implementation(project(":features:core:calculator"))
   implementation(project(":features:core:database"))
-  implementation(project(":features:core:ui"))
   implementation(project(":features:mobile:ui"))
-  implementation(libs.androidx.compose.material3)
-  implementation(libs.androidx.compose.material3.wsc)
-  implementation(libs.bundles.m3.adaptive)
 }

--- a/features/mobile/calculator-input/build.gradle.kts
+++ b/features/mobile/calculator-input/build.gradle.kts
@@ -14,9 +14,5 @@ android {
 
 dependencies {
   implementation(project(":features:core:calculator"))
-  implementation(project(":features:core:ui"))
   implementation(project(":features:mobile:ui"))
-  implementation(libs.androidx.compose.material3)
-  implementation(libs.androidx.compose.material3.wsc)
-  implementation(libs.bundles.m3.adaptive)
 }

--- a/features/mobile/calculator-output/build.gradle.kts
+++ b/features/mobile/calculator-output/build.gradle.kts
@@ -15,9 +15,5 @@ android {
 dependencies {
   implementation(project(":features:core:calculator"))
   implementation(project(":features:core:database"))
-  implementation(project(":features:core:ui"))
   implementation(project(":features:mobile:ui"))
-  implementation(libs.androidx.compose.material3)
-  implementation(libs.androidx.compose.material3.wsc)
-  implementation(libs.bundles.m3.adaptive)
 }

--- a/features/mobile/onboarding/build.gradle.kts
+++ b/features/mobile/onboarding/build.gradle.kts
@@ -4,8 +4,8 @@
  */
 
 plugins {
-  id("mocca.android.lib.mobile")
   id("mocca.compose.lib")
+  id("mocca.android.lib.mobile")
 }
 
 android {
@@ -13,9 +13,5 @@ android {
 }
 
 dependencies {
-  implementation(project(":features:core:ui"))
   implementation(project(":features:mobile:ui"))
-  implementation(libs.androidx.compose.material3)
-  implementation(libs.androidx.compose.material3.wsc)
-  implementation(libs.bundles.m3.adaptive)
 }

--- a/features/mobile/settings/build.gradle.kts
+++ b/features/mobile/settings/build.gradle.kts
@@ -13,10 +13,6 @@ android {
 }
 
 dependencies {
-  implementation(project(":features:core:preferences"))
-  implementation(project(":features:core:ui"))
   implementation(project(":features:mobile:ui"))
-  implementation(libs.androidx.compose.material3)
-  implementation(libs.androidx.compose.material3.wsc)
-  implementation(libs.bundles.m3.adaptive)
+  implementation(project(":features:core:preferences"))
 }

--- a/features/mobile/ui/build.gradle.kts
+++ b/features/mobile/ui/build.gradle.kts
@@ -4,8 +4,8 @@
  */
 
 plugins {
-  id("mocca.android.lib.mobile")
   id("mocca.compose.lib")
+  id("mocca.android.lib.mobile")
   id("kotlin-parcelize")
 }
 
@@ -14,9 +14,5 @@ android {
 }
 
 dependencies {
-  implementation(project(":features:core:ui"))
   implementation(libs.androidx.browser)
-  implementation(libs.androidx.compose.material3)
-  implementation(libs.androidx.compose.material3.wsc)
-  implementation(libs.bundles.m3.adaptive)
 }


### PR DESCRIPTION
## Overview
This PR refactors the dependency management for mobile feature modules by centralizing Material3 and Material3 Adaptive libraries inside the `MobileAndroidLibPlugin` convention plugin. It removes repetitive configuration boilerplate from individual feature build files.

## Changes Made
- **Build Logic**: Updated `MobileAndroidLibPlugin.kt` to inject `androidx-compose-material3`, `androidx-compose-material3-wsc`, and `m3-adaptive` into the target project's dependency block.
- **Feature Modules**: Cleared out explicit, duplicate declarations of these dependencies and removed redundant `:features:core:ui` projects from:
  - `:features:mobile:calculator-fees`
  - `:features:mobile:calculator-history`
  - `:features:mobile:calculator-input`
  - `:features:mobile:calculator-output`
  - `:features:mobile:onboarding`
  - `:features:mobile:settings`
  - `:features:mobile:ui`

## Granular Commit History
To make this easy to review, the changes have been split into the following atomic commits:
- [x] `build(convention): add Material3 and Adaptive dependencies to MobileAndroidLibPlugin`
- [x] `refactor(calculator-fees): remove explicit Material3 and core:ui dependencies`
- [x] `refactor(calculator-history): remove explicit Material3 and core:ui dependencies`
- [x] `refactor(calculator-input): remove explicit Material3 and core:ui dependencies`
- [x] `refactor(calculator-output): remove explicit Material3 and core:ui dependencies`
- [x] `refactor(onboarding): remove explicit Material3 and core:ui dependencies`
- [x] `refactor(settings): remove explicit Material3 and core:ui dependencies`
- [x] `refactor(mobile:ui): remove explicit Material3 and core:ui dependencies`

## Testing Lifecycle
- [x] Executed `./gradlew clean build` successfully.
- [x] Verified that mobile UI components, window size class adjustments, and adaptive layouts render correctly without compilation or runtime classpath issues.