### PR TITLE
Remove empty dependencies block from build.gradle.kts

### DIFF
--- a/features/wearos/ui/build.gradle.kts
+++ b/features/wearos/ui/build.gradle.kts
@@ -12,6 +12,3 @@ plugins {
 android {
   namespace = "dev.marlonlom.mocca.wearos.ui"
 }
-
-dependencies {
-}


### PR DESCRIPTION
Remove empty dependencies block from build.gradle.kts in wearos:ui feature module