### PR TITLE
refactor(convention): modularize build logic and prune redundant dependencies

### DIFF
--- a/apps/mobile/build.gradle.kts
+++ b/apps/mobile/build.gradle.kts
@@ -21,21 +21,4 @@ dependencies {
   implementation(project(":features:mobile:onboarding"))
   implementation(project(":features:mobile:settings"))
   implementation(project(":features:mobile:ui"))
-
-  val composeBom = platform(libs.androidx.compose.bom)
-  implementation(composeBom)
-  androidTestImplementation(composeBom)
-
-  implementation(libs.androidx.appcompat)
-  implementation(libs.androidx.browser)
-  implementation(libs.androidx.compose.material3)
-  implementation(libs.androidx.compose.material3.wsc)
-  implementation(libs.androidx.compose.ui.googlefonts)
-  implementation(libs.androidx.lifecycle.runtime.compose)
-  implementation(libs.androidx.lifecycle.runtime.ktx)
-  implementation(libs.androidx.lifecycle.viewmodel.compose)
-  implementation(libs.androidx.window)
-  implementation(libs.google.oss.licenses)
-
-  androidTestImplementation(libs.androidx.window.testing)
 }

--- a/apps/wearos/build.gradle.kts
+++ b/apps/wearos/build.gradle.kts
@@ -12,15 +12,4 @@ dependencies {
 
   implementation(project(":features:core:calculator"))
   implementation(project(":features:wearos:ui"))
-
-  val composeBom = platform(libs.androidx.compose.bom)
-  implementation(composeBom)
-  androidTestImplementation(composeBom)
-
-  implementation(libs.androidx.compose.ui.tooling)
-  implementation(libs.androidx.lifecycle.runtime.ktx)
-  implementation(libs.androidx.wear.compose.foundation)
-  implementation(libs.androidx.wear.compose.material3)
-  implementation(libs.androidx.wear.compose.navigation)
-  implementation(libs.google.play.services.wearable)
 }

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/extensions/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/extensions/AndroidCompose.kt
@@ -39,7 +39,6 @@ internal fun Project.configureAndroidCompose(
 
       add("androidTestImplementation", vc.findLibrary("android-arch-core-testing").get())
       add("androidTestImplementation", vc.findLibrary("androidx-compose-ui-test-junit4").get())
-      add("androidTestImplementation", vc.findLibrary("google-truth").get())
 
       add("debugImplementation", vc.findLibrary("androidx-compose-ui-tooling").get())
       add("debugImplementation", vc.findLibrary("androidx-compose-ui-test-manifest").get())

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/extensions/AndroidKotlin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/extensions/AndroidKotlin.kt
@@ -8,10 +8,47 @@ package dev.marlonlom.mocca.extensions
 import com.android.build.api.dsl.CommonExtension
 import dev.marlonlom.mocca.configs.Config
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+/**
+ * Extension function on [DependencyHandlerScope] to automatically register android ui testing
+ * dependencies from the project's version catalog.
+ *
+ * It iterates through a predefined list of test library aliases
+ * and safely adds them to the "androidTestImplementation" configuration if they exist in the catalog.
+ *
+ * @param project The [Project] instance used to fetch the version catalog.
+ */
+private fun DependencyHandlerScope.addAndroidTestDependencies(project: Project) {
+  val catalog = project.versionCatalog()
+  listOf("google-truth", "androidx-test-espresso-core", "androidx-test-ext-junit").forEach { alias ->
+    catalog.findLibrary(alias).ifPresent { library ->
+      add("androidTestImplementation", library)
+    }
+  }
+}
+
+/**
+ * Extension function on [DependencyHandlerScope] to automatically register core unit testing
+ * dependencies from the project's version catalog.
+ *
+ * It iterates through a predefined list of test library aliases
+ * and safely adds them to the "testImplementation" configuration if they exist in the catalog.
+ *
+ * @param project The [Project] instance used to fetch the version catalog.
+ */
+private fun DependencyHandlerScope.addTestDependencies(project: Project) {
+  val catalog = project.versionCatalog()
+  listOf("junit", "kotlinx-coroutines-test", "mockk").forEach { alias ->
+    catalog.findLibrary(alias).ifPresent { library ->
+      add("testImplementation", library)
+    }
+  }
+}
 
 /**
  * Configures common Kotlin and JVM settings for Android modules.
@@ -19,31 +56,22 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
  * This function standardizes the Kotlin compiler options, JVM target versions,
  * and Java toolchain settings across Application and Library extensions.
  *
- * @author marlonlom
- *
  * @param extension The Android [CommonExtension] to be configured with Kotlin-specific settings.
  */
-internal fun Project.configureAndroidKotlin(
+private fun Project.configureCommonAndroidKotlin(
   extension: CommonExtension
 ) {
   with(extension) {
-
     compileOptions.sourceCompatibility = Config.jvm.javaVersion
     compileOptions.targetCompatibility = Config.jvm.javaVersion
 
     packaging.resources.excludes += "/META-INF/{AL2.0,LGPL2.1}"
 
     dependencies {
-      add("implementation", versionCatalog().findLibrary("androidx-core-ktx").get())
       add("implementation", versionCatalog().findLibrary("androidx-core-splashscreen").get())
-
-      add("testImplementation", versionCatalog().findLibrary("junit").get())
-      add("testImplementation", versionCatalog().findLibrary("kotlinx-coroutines-test").get())
-      add("testImplementation", versionCatalog().findLibrary("mockk").get())
-
-      add("androidTestImplementation", versionCatalog().findLibrary("androidx-test-espresso-core").get())
-      add("androidTestImplementation", versionCatalog().findLibrary("androidx-test-ext-junit").get())
-      add("androidTestImplementation", versionCatalog().findLibrary("google-truth").get())
+      add("implementation", versionCatalog().findLibrary("androidx-lifecycle-runtime-ktx").get())
+      addTestDependencies(this@configureCommonAndroidKotlin)
+      addAndroidTestDependencies(this@configureCommonAndroidKotlin)
     }
   }
 
@@ -52,4 +80,33 @@ internal fun Project.configureAndroidKotlin(
       jvmTarget.set(JvmTarget.fromTarget(Config.jvm.kotlinJvm))
     }
   }
+}
+
+/**
+ * Configures common Kotlin and JVM settings for Mobile modules.
+ *
+ * @author marlonlom
+ *
+ * @param extension The Android [CommonExtension] to be configured with Kotlin-specific settings.
+ */
+internal fun Project.configureMobileAndroidKotlin(
+  extension: CommonExtension
+) {
+  configureCommonAndroidKotlin(extension)
+  dependencies {
+    add("implementation", versionCatalog().findLibrary("androidx-core-ktx").get())
+  }
+}
+
+/**
+ * Configures common Kotlin and JVM settings for Wearos modules.
+ *
+ * @author marlonlom
+ *
+ * @param extension The Android [CommonExtension] to be configured with Kotlin-specific settings.
+ */
+internal fun Project.configureWearosAndroidKotlin(
+  extension: CommonExtension
+) {
+  configureCommonAndroidKotlin(extension)
 }

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/apps/CommonAndroidAppPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/apps/CommonAndroidAppPlugin.kt
@@ -6,7 +6,6 @@
 package dev.marlonlom.mocca.plugins.apps
 
 import com.android.build.api.dsl.ApplicationExtension
-import dev.marlonlom.mocca.extensions.configureAndroidKotlin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
@@ -31,7 +30,6 @@ class CommonAndroidAppPlugin : Plugin<Project> {
       extensions.configure<ApplicationExtension> {
         defaultConfig.vectorDrawables.useSupportLibrary = true
         buildFeatures.buildConfig = true
-        configureAndroidKotlin(this)
 
         buildTypes {
 

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/apps/MobileAndroidAppPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/apps/MobileAndroidAppPlugin.kt
@@ -7,9 +7,12 @@ package dev.marlonlom.mocca.plugins.apps
 
 import com.android.build.api.dsl.ApplicationExtension
 import dev.marlonlom.mocca.configs.Config
+import dev.marlonlom.mocca.extensions.configureMobileAndroidKotlin
+import dev.marlonlom.mocca.extensions.versionCatalog
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 
 /**
  * A convention plugin specifically for configuring mobile Android application conventions.
@@ -32,6 +35,22 @@ class MobileAndroidAppPlugin : Plugin<Project> {
           versionCode = Config.mobile.versionCode
           versionName = Config.mobile.versionName
           testInstrumentationRunner = Config.mobile.testInstrumentationRunner
+        }
+
+        configureMobileAndroidKotlin(this)
+
+        dependencies {
+          val vc = versionCatalog()
+          add("implementation", vc.findLibrary("androidx-appcompat").get())
+          add("implementation", vc.findLibrary("androidx-browser").get())
+          add("implementation", vc.findLibrary("androidx-compose-material3").get())
+          add("implementation", vc.findLibrary("androidx-compose-material3-wsc").get())
+          add("implementation", vc.findLibrary("androidx-compose-ui-googlefonts").get())
+          add("implementation", vc.findLibrary("androidx-lifecycle-runtime-compose").get())
+          add("implementation", vc.findLibrary("androidx-lifecycle-viewmodel-compose").get())
+          add("implementation", vc.findLibrary("androidx-window").get())
+          add("implementation", vc.findLibrary("google-oss-licenses").get())
+          add("androidTestImplementation", vc.findLibrary("androidx-window-testing").get())
         }
       }
     }

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/apps/WearosAndroidAppPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/apps/WearosAndroidAppPlugin.kt
@@ -7,9 +7,12 @@ package dev.marlonlom.mocca.plugins.apps
 
 import com.android.build.api.dsl.ApplicationExtension
 import dev.marlonlom.mocca.configs.Config
+import dev.marlonlom.mocca.extensions.configureWearosAndroidKotlin
+import dev.marlonlom.mocca.extensions.versionCatalog
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 
 /**
  * A convention plugin specifically for configuring wearos Android application conventions.
@@ -21,6 +24,13 @@ class WearosAndroidAppPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     with(project) {
       pluginManager.apply("mocca.android.app.common")
+      val vc = versionCatalog()
+      dependencies {
+        add("implementation", vc.findLibrary("androidx-wear-compose-foundation").get())
+        add("implementation", vc.findLibrary("androidx-wear-compose-material3").get())
+        add("implementation", vc.findLibrary("androidx-wear-compose-navigation").get())
+        add("implementation", vc.findLibrary("google-play-services-wearable").get())
+      }
       extensions.configure<ApplicationExtension> {
         namespace = Config.wearos.nameSpace
         compileSdk = Config.wearos.compileSdkVersion
@@ -33,6 +43,8 @@ class WearosAndroidAppPlugin : Plugin<Project> {
           versionName = Config.wearos.versionName
           testInstrumentationRunner = Config.wearos.testInstrumentationRunner
         }
+
+        configureWearosAndroidKotlin(this)
       }
     }
   }

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/apps/WearosAndroidAppPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/apps/WearosAndroidAppPlugin.kt
@@ -24,13 +24,7 @@ class WearosAndroidAppPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     with(project) {
       pluginManager.apply("mocca.android.app.common")
-      val vc = versionCatalog()
-      dependencies {
-        add("implementation", vc.findLibrary("androidx-wear-compose-foundation").get())
-        add("implementation", vc.findLibrary("androidx-wear-compose-material3").get())
-        add("implementation", vc.findLibrary("androidx-wear-compose-navigation").get())
-        add("implementation", vc.findLibrary("google-play-services-wearable").get())
-      }
+
       extensions.configure<ApplicationExtension> {
         namespace = Config.wearos.nameSpace
         compileSdk = Config.wearos.compileSdkVersion
@@ -45,6 +39,14 @@ class WearosAndroidAppPlugin : Plugin<Project> {
         }
 
         configureWearosAndroidKotlin(this)
+
+        dependencies {
+          val vc = versionCatalog()
+          add("implementation", vc.findLibrary("androidx-wear-compose-foundation").get())
+          add("implementation", vc.findLibrary("androidx-wear-compose-material3").get())
+          add("implementation", vc.findLibrary("androidx-wear-compose-navigation").get())
+          add("implementation", vc.findLibrary("google-play-services-wearable").get())
+        }
       }
     }
   }

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/CommonAndroidLibPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/CommonAndroidLibPlugin.kt
@@ -6,13 +6,17 @@
 package dev.marlonlom.mocca.plugins.libs
 
 import com.android.build.api.dsl.LibraryExtension
-import dev.marlonlom.mocca.extensions.configureAndroidKotlin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
 
+/**
+ * A convention plugin for configuring common Android libraries.
+ *
+ * @author marlonlom
+ */
 class CommonAndroidLibPlugin : Plugin<Project> {
 
   override fun apply(project: Project) {
@@ -27,7 +31,6 @@ class CommonAndroidLibPlugin : Plugin<Project> {
 
       extensions.configure<LibraryExtension> {
         defaultConfig.vectorDrawables.useSupportLibrary = true
-        configureAndroidKotlin(this)
         buildTypes {
           release {
             isMinifyEnabled = false

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/MobileAndroidLibPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/MobileAndroidLibPlugin.kt
@@ -7,22 +7,24 @@ package dev.marlonlom.mocca.plugins.libs
 
 import com.android.build.api.dsl.LibraryExtension
 import dev.marlonlom.mocca.configs.Config
+import dev.marlonlom.mocca.extensions.configureMobileAndroidKotlin
 import dev.marlonlom.mocca.extensions.versionCatalog
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 
+/**
+ * A convention plugin for configuring Android Mobile libraries.
+ *
+ * @author marlonlom
+ */
 class MobileAndroidLibPlugin : Plugin<Project> {
 
   override fun apply(project: Project) {
     with(project) {
       pluginManager.apply("mocca.android.lib.common")
-      dependencies {
-        add("implementation", versionCatalog().findLibrary("androidx-compose-material3").get())
-        add("implementation", versionCatalog().findLibrary("androidx-compose-material3-wsc").get())
-        add("implementation", versionCatalog().findBundle("m3-adaptive").get())
-      }
+
       extensions.configure<LibraryExtension> {
         namespace = Config.mobile.nameSpace
         compileSdk = Config.mobile.compileSdkVersion
@@ -30,6 +32,15 @@ class MobileAndroidLibPlugin : Plugin<Project> {
         defaultConfig {
           minSdk = Config.mobile.minSdkVersion
           testInstrumentationRunner = Config.mobile.testInstrumentationRunner
+        }
+
+        configureMobileAndroidKotlin(this)
+
+        dependencies {
+          val vc = versionCatalog()
+          add("implementation", vc.findLibrary("androidx-compose-material3").get())
+          add("implementation", vc.findLibrary("androidx-compose-material3-wsc").get())
+          add("implementation", vc.findBundle("m3-adaptive").get())
         }
       }
     }

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/WearosAndroidLibPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/WearosAndroidLibPlugin.kt
@@ -28,6 +28,7 @@ class WearosAndroidLibPlugin : Plugin<Project> {
         val vc = versionCatalog()
         add("implementation", vc.findLibrary("androidx-wear-compose-foundation").get())
         add("implementation", vc.findLibrary("androidx-wear-compose-material3").get())
+        add("implementation", vc.findLibrary("androidx-wear-compose-navigation").get())
       }
       extensions.configure<LibraryExtension> {
         namespace = Config.wearos.nameSpace

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/WearosAndroidLibPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/WearosAndroidLibPlugin.kt
@@ -7,6 +7,7 @@ package dev.marlonlom.mocca.plugins.libs
 
 import com.android.build.api.dsl.LibraryExtension
 import dev.marlonlom.mocca.configs.Config
+import dev.marlonlom.mocca.extensions.configureWearosAndroidKotlin
 import dev.marlonlom.mocca.extensions.versionCatalog
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -24,9 +25,9 @@ class WearosAndroidLibPlugin : Plugin<Project> {
     with(project) {
       pluginManager.apply("mocca.android.lib.common")
       dependencies {
-        add("implementation", versionCatalog().findLibrary("androidx-wear-compose-foundation").get())
-        add("implementation", versionCatalog().findLibrary("androidx-wear-compose-material3").get())
-        add("implementation", versionCatalog().findLibrary("androidx-wear-compose-navigation").get())
+        val vc = versionCatalog()
+        add("implementation", vc.findLibrary("androidx-wear-compose-foundation").get())
+        add("implementation", vc.findLibrary("androidx-wear-compose-material3").get())
       }
       extensions.configure<LibraryExtension> {
         namespace = Config.wearos.nameSpace
@@ -36,6 +37,8 @@ class WearosAndroidLibPlugin : Plugin<Project> {
           minSdk = Config.wearos.minSdkVersion
           testInstrumentationRunner = Config.wearos.testInstrumentationRunner
         }
+
+        configureWearosAndroidKotlin(this)
       }
     }
   }

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/WearosAndroidLibPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/libs/WearosAndroidLibPlugin.kt
@@ -28,7 +28,6 @@ class WearosAndroidLibPlugin : Plugin<Project> {
         val vc = versionCatalog()
         add("implementation", vc.findLibrary("androidx-wear-compose-foundation").get())
         add("implementation", vc.findLibrary("androidx-wear-compose-material3").get())
-        add("implementation", vc.findLibrary("androidx-wear-compose-navigation").get())
       }
       extensions.configure<LibraryExtension> {
         namespace = Config.wearos.nameSpace

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/utils/KoinPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/utils/KoinPlugin.kt
@@ -18,9 +18,10 @@ class KoinPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     with(project) {
       dependencies {
-        val composeBom = platform(versionCatalog().findLibrary("koin-bom").get())
-        add("implementation", composeBom)
-        add("implementation", versionCatalog().findBundle("koin").get())
+        val vc = versionCatalog()
+        val koinBom = platform(vc.findLibrary("koin-bom").get())
+        add("implementation", koinBom)
+        add("implementation", vc.findBundle("koin").get())
       }
     }
   }

--- a/features/core/database/build.gradle.kts
+++ b/features/core/database/build.gradle.kts
@@ -18,7 +18,6 @@ android {
 }
 
 dependencies {
-  implementation(libs.androidx.appcompat)
   implementation(libs.bundles.database.room)
 
   ksp(libs.androidx.room.compiler)

--- a/features/wearos/ui/build.gradle.kts
+++ b/features/wearos/ui/build.gradle.kts
@@ -12,3 +12,7 @@ plugins {
 android {
   namespace = "dev.marlonlom.mocca.wearos.ui"
 }
+
+dependencies {
+  implementation(libs.androidx.wear.compose.navigation)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ androidx-room = "2.8.4"
 
 # Compose & Navigation
 androidx-compose-bom = "2026.05.01"
-navigation-compose = "2.9.8"
 m3-adaptive = "1.2.0"
 m3-adaptive-suite = "1.4.0"
 wearos-compose = "1.6.2"
@@ -75,7 +74,6 @@ androidx-compose-ui-googlefonts = { module = "androidx.compose.ui:ui-text-google
 androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 
 # Material3 Adaptive
 androidx-m3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "m3-adaptive" }


### PR DESCRIPTION
### Summary
This PR refactors our internal Gradle convention plugins to support platform-specific Kotlin configurations, subsequently cleaning up boilerplate dependency declarations across various application and library modules. It also removes an unused navigation dependency from the version catalog.

### Chaos / Changes Breakdown

#### 1. Build Logic Refactoring (`build-logic/convention`)
* Split the monolithic `configureAndroidKotlin` function into specialized `configureMobileAndroidKotlin` and `configureWearosAndroidKotlin` extensions.
* Extracted `addTestDependencies` and `addAndroidTestDependencies` helper functions to safely iterate over and add catalog dependencies.
* Cached `versionCatalog()` lookups into a local `vc` variable across plugins to minimize repetitive calls.

#### 2. Module Cleanups (`apps/` & `features/`)
* **Mobile & Wear OS Apps:** Removed explicit declarations for the Compose BOM, standard lifecycle, and Wear OS libraries from `build.gradle.kts` files since they are now injected via the new platform-specific convention extensions.
* **Database Core Feature:** Stripped the unused `androidx.appcompat` dependency.

#### 3. Version Catalog (`gradle/libs.versions.toml`)
* Completely removed the `navigation-compose` version reference and the `androidx-navigation-compose` library declaration.

### Verification Done
- [x] Executed `./gradlew clean build` successfully.
- [x] Verified that both Mobile and Wear OS targets compile and resolve all required dependencies natively.