### PR TITLE
feat(wearos): add calculator-fees module and implement list screen

### DIFF
--- a/apps/wearos/build.gradle.kts
+++ b/apps/wearos/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
 dependencies {
 
   implementation(project(":features:core:calculator"))
+  implementation(project(":features:wearos:calculator-fees"))
   implementation(project(":features:wearos:calculator-input"))
   implementation(project(":features:wearos:calculator-output"))
   implementation(project(":features:wearos:ui"))

--- a/features/wearos/calculator-fees/build.gradle.kts
+++ b/features/wearos/calculator-fees/build.gradle.kts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+  id("mocca.android.lib.wearos")
+  id("mocca.compose.lib")
+}
+
+android {
+  namespace = "dev.marlonlom.mocca.wearos.calculator.fees"
+}
+
+dependencies {
+  implementation(project(":features:core:calculator"))
+  implementation(project(":features:wearos:ui"))
+}

--- a/features/wearos/calculator-fees/src/androidTest/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/CalculatorFeesListScreenUiTest.kt
+++ b/features/wearos/calculator-fees/src/androidTest/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/CalculatorFeesListScreenUiTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.marlonlom.mocca.wearos.calculator.fees
+
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+internal class CalculatorFeesListScreenUiTest {
+
+  @get:Rule
+  var rule = createComposeRule()
+
+  @Test
+  fun shouldDisplayListScreen() {
+    with(rule) {
+      setContent {
+        CalculatorFeesListScreen(
+          onBackNavigationAction = {},
+        )
+      }
+      onNodeWithText("Fees (COP)").assertExists()
+    }
+  }
+
+}

--- a/features/wearos/calculator-fees/src/androidTest/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/CalculatorFeesListScreenUiTest.kt
+++ b/features/wearos/calculator-fees/src/androidTest/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/CalculatorFeesListScreenUiTest.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright 2026 Marlonlom
+ * Copyright 2024 Marlonlom
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package dev.marlonlom.mocca.wearos.calculator.fees
 
 import androidx.compose.ui.test.junit4.v2.createComposeRule
@@ -26,5 +25,4 @@ internal class CalculatorFeesListScreenUiTest {
       onNodeWithText("Fees (COP)").assertExists()
     }
   }
-
 }

--- a/features/wearos/calculator-fees/src/androidTest/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/component/CalculationFeeListItemUiTest.kt
+++ b/features/wearos/calculator-fees/src/androidTest/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/component/CalculationFeeListItemUiTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.marlonlom.mocca.wearos.calculator.fees.component
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import dev.marlonlom.mocca.wearos.calculator.fees.domain.CalculatingFeesDomainData
+import org.junit.Rule
+import org.junit.Test
+
+internal class CalculationFeeListItemUiTest {
+
+  @get:Rule
+  var rule = createComposeRule()
+
+  @Test
+  fun shouldDisplayListItemScreenWithFixedFee() {
+    with(rule) {
+      setContent {
+        CalculationFeeListItem(
+          position = 1,
+          domainItem = CalculatingFeesDomainData(
+            min = 5000.0,
+            max = 50000.0,
+            fixedFee = 4700.0,
+            haveVariableFee = false,
+            variableFeeFactor = 0.0
+          )
+        )
+      }
+      onNodeWithText("4%").assertIsNotDisplayed()
+      onNodeWithText("$4.700").assertIsNotDisplayed()
+      onNodeWithText("From $5K to $50K").assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun shouldDisplayListItemScreenWithVariableFee() {
+    with(rule) {
+      setContent {
+        CalculationFeeListItem(
+          position = 1,
+          domainItem = CalculatingFeesDomainData(
+            min = 200_001.0,
+            max = 3_000_000.0,
+            fixedFee = 0.0,
+            haveVariableFee = true,
+            variableFeeFactor = 4.0
+          )
+        )
+      }
+
+      onNodeWithText("4%").assertIsDisplayed()
+      onNodeWithText("From $200K to $3M").assertIsDisplayed()
+    }
+  }
+}

--- a/features/wearos/calculator-fees/src/androidTest/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/component/CalculationFeeListItemUiTest.kt
+++ b/features/wearos/calculator-fees/src/androidTest/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/component/CalculationFeeListItemUiTest.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright 2026 Marlonlom
+ * Copyright 2024 Marlonlom
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package dev.marlonlom.mocca.wearos.calculator.fees.component
 
 import androidx.compose.ui.test.assertIsDisplayed
@@ -29,8 +28,8 @@ internal class CalculationFeeListItemUiTest {
             max = 50000.0,
             fixedFee = 4700.0,
             haveVariableFee = false,
-            variableFeeFactor = 0.0
-          )
+            variableFeeFactor = 0.0,
+          ),
         )
       }
       onNodeWithText("4%").assertIsNotDisplayed()
@@ -50,8 +49,8 @@ internal class CalculationFeeListItemUiTest {
             max = 3_000_000.0,
             fixedFee = 0.0,
             haveVariableFee = true,
-            variableFeeFactor = 4.0
-          )
+            variableFeeFactor = 4.0,
+          ),
         )
       }
 

--- a/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/CalculatorFeesListScreen.kt
+++ b/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/CalculatorFeesListScreen.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.wearos.calculator.fees
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.itemsIndexed
+import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import dev.marlonlom.mocca.wearos.calculator.fees.component.CalculationFeeListItem
+import dev.marlonlom.mocca.wearos.calculator.fees.domain.CalculatingFeesDomainData
+import dev.marlonlom.mocca.wearos.calculator.fees.domain.CalculatorFeesProvider
+
+/**
+ * Displays a list-based screen showing calculation fees.
+ *
+ * @author marlonlom
+ *
+ * @param onBackNavigationAction Callback invoked when the user requests to navigate
+ * back to the previous screen.
+ */
+@Composable
+fun CalculatorFeesListScreen(onBackNavigationAction: () -> Unit) {
+  BackHandler {
+    onBackNavigationAction()
+  }
+  val feesListingsState: List<CalculatingFeesDomainData> = remember {
+    CalculatorFeesProvider.provideFees()
+  }
+  val listState = rememberScalingLazyListState()
+  ScalingLazyColumn(
+    state = listState,
+    modifier = Modifier
+      .fillMaxSize()
+      .background(MaterialTheme.colorScheme.background),
+    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 20.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    item {
+      Text(
+        modifier = Modifier.fillMaxWidth(),
+        textAlign = TextAlign.Center,
+        style = MaterialTheme.typography.bodyMedium,
+        text = stringResource(R.string.text_fees),
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+      )
+      Spacer(Modifier.height(10.dp))
+    }
+    itemsIndexed(items = feesListingsState) { position, item ->
+      CalculationFeeListItem(
+        position = position,
+        domainItem = item,
+      )
+    }
+  }
+}

--- a/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/component/CalculationFeeListItem.kt
+++ b/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/component/CalculationFeeListItem.kt
@@ -34,10 +34,7 @@ import dev.marlonlom.mocca.wearos.calculator.fees.domain.ColombianPesoFormatter
  * @param domainItem The domain data model containing the fee information to be rendered.
  */
 @Composable
-internal fun CalculationFeeListItem(
-  position: Int,
-  domainItem: CalculatingFeesDomainData,
-) = Box(
+internal fun CalculationFeeListItem(position: Int, domainItem: CalculatingFeesDomainData) = Box(
   modifier = Modifier
     .testTag("calculation_fee_list_item_$position")
     .fillMaxWidth()

--- a/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/component/CalculationFeeListItem.kt
+++ b/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/component/CalculationFeeListItem.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.wearos.calculator.fees.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import dev.marlonlom.mocca.wearos.calculator.fees.R
+import dev.marlonlom.mocca.wearos.calculator.fees.domain.CalculatingFeesDomainData
+import dev.marlonlom.mocca.wearos.calculator.fees.domain.ColombianPesoFormatter
+
+/**
+ * A list item component that displays the fee details for a single [CalculatingFeesDomainData] record.
+ *
+ * @author marlonlom
+ *
+ * @param domainItem The domain data model containing the fee information to be rendered.
+ */
+@Composable
+internal fun CalculationFeeListItem(
+  position: Int,
+  domainItem: CalculatingFeesDomainData,
+) = Box(
+  modifier = Modifier
+    .testTag("calculation_fee_list_item_$position")
+    .fillMaxWidth()
+    .height(48.dp)
+    .background(
+      color = MaterialTheme.colorScheme.surfaceContainerLow,
+      shape = RoundedCornerShape(percent = 50),
+    )
+    .padding(horizontal = 20.dp),
+  contentAlignment = Alignment.CenterStart,
+) {
+  Column(
+    verticalArrangement = Arrangement.Center,
+  ) {
+    Text(
+      text = if (domainItem.haveVariableFee) {
+        stringResource(
+          R.string.text_fee_percentage,
+          domainItem.variableFeeFactor,
+        )
+      } else {
+        ColombianPesoFormatter.formatCOP(domainItem.fixedFee.toLong())
+      },
+      maxLines = 1,
+      fontWeight = FontWeight.Bold,
+      style = MaterialTheme.typography.labelMedium,
+      color = MaterialTheme.colorScheme.onSecondaryContainer,
+    )
+    Spacer(modifier = Modifier.height(2.dp))
+    Text(
+      text = stringResource(
+        R.string.text_price_range,
+        ColombianPesoFormatter.format(domainItem.min.toLong()),
+        ColombianPesoFormatter.format(domainItem.max.toLong()),
+      ),
+      maxLines = 1,
+      style = MaterialTheme.typography.bodyExtraSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+  }
+}

--- a/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/domain/CalculatingFeesDomainData.kt
+++ b/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/domain/CalculatingFeesDomainData.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.wearos.calculator.fees.domain
+
+/**
+ * Represents the result of a calculation in the domain layer.
+ *
+ * @author marlonlom
+ *
+ * @property min Minimum value for the fee range.
+ * @property max Maximum value for the fee range.
+ * @property fixedFee Fixed fee value.
+ * @property haveVariableFee Indicates if variable fee is included.
+ * @property variableFeeFactor Variable fee factor value.
+ *
+ */
+data class CalculatingFeesDomainData(
+  val min: Double,
+  val max: Double,
+  val fixedFee: Double,
+  val haveVariableFee: Boolean,
+  val variableFeeFactor: Double,
+)

--- a/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/domain/CalculatorFeesProvider.kt
+++ b/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/domain/CalculatorFeesProvider.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.wearos.calculator.fees.domain
+
+import dev.marlonlom.mocca.calculator.Calculator
+import dev.marlonlom.mocca.calculator.model.OrderFees
+
+/**
+ * Calculator fees domain data provider object.
+ *
+ * @author marlonlom
+ */
+object CalculatorFeesProvider {
+
+  /** Zero value for fees. */
+  private const val ZERO = 0.0
+
+  /** Lambda for retrieving the variable fee factor. */
+  private val variableFeeFactor: () -> Double = { Calculator.VARIABLE_FEE_FACTOR }
+
+  /**
+   * Provides the complete list of successful domain fees.
+   *
+   * @return A list of [CalculatingFeesDomainData] with computed fee factors.
+   */
+  fun provideFees(): List<CalculatingFeesDomainData> = OrderFees.entries.toList().map { fee ->
+    CalculatingFeesDomainData(
+      min = fee.min,
+      max = fee.max,
+      fixedFee = fee.fixedFee,
+      haveVariableFee = fee.haveVariableFee,
+      variableFeeFactor = if (fee.haveVariableFee) variableFeeFactor() else ZERO,
+    )
+  }
+}

--- a/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/domain/ColombianPesoFormatter.kt
+++ b/features/wearos/calculator-fees/src/main/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/domain/ColombianPesoFormatter.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.wearos.calculator.fees.domain
+
+import java.text.NumberFormat
+import java.util.Locale
+
+/**
+ * Utility object for formatting monetary values in Colombian Pesos (COP) and creating
+ * compact numeric representations.
+ *
+ * @author marlonlom
+ */
+object ColombianPesoFormatter {
+
+  /**
+   * Formats a raw numeric [value] into a standard Colombian Peso currency string representation.
+   *
+   * This method applies the `es-CO` locale rules, ensuring the correct currency symbols,
+   * thousands separators, and truncates all decimal fractional digits since COP does not
+   * practically use cents.
+   *
+   * Example: `1500000` becomes `"$ 1.500.000"` (exact spacing depends on OS/Java runtime locale data).
+   *
+   * @param value The amount in Colombian Pesos as a [Long].
+   * @return A localized, formatted currency [String] with zero decimal digits.
+   */
+  fun formatCOP(value: Long): String = NumberFormat
+    .getCurrencyInstance(Locale.forLanguageTag("es-CO"))
+    .also {
+      it.maximumFractionDigits = 0
+      it.minimumFractionDigits = 0
+    }
+    .format(value)
+
+  /**
+   * Formats a numeric [value] into a compact, human-readable abbreviation (e.g., thousands as 'K', millions as 'M').
+   *
+   * The abbreviation rounds down to a single decimal place if a fraction exists, dropping trailing
+   * zeros if it evaluates to a whole number.
+   *
+   * Examples:
+   * - `format(500)` -> `"$500"`
+   * - `format(1500)` -> `"$1.5K"`
+   * - `format(2000000)` -> `"$2M"`
+   *
+   * @param value The amount to be formatted as a [Long].
+   * @param symbol The currency prefix to append. Defaults to `"$"` if not provided.
+   * @return A compact formatted [String] representation of the value.
+   */
+  fun format(value: Long, symbol: String = "$"): String = symbol + when {
+    value >= 1_000_000 -> formatDecimal(value / 1_000_000.0) + "M"
+    value >= 1_000 -> formatDecimal(value / 1_000.0) + "K"
+    else -> value.toString()
+  }
+
+  /**
+   * Truncates a [Double] value to one decimal place and formats it as a string.
+   *
+   * If the truncated value has no fractional part (e.g., `2.0`), it drops the decimal
+   * entirely and returns a whole number string (`"2"`).
+   *
+   * @param value The decimal number to format.
+   * @return A [String] representation of the number rounded to a single decimal point.
+   */
+  private fun formatDecimal(value: Double): String {
+    val rounded = (value * 10).toInt() / 10.0
+    return if (rounded % 1.0 == 0.0) {
+      rounded.toInt().toString()
+    } else {
+      rounded.toString()
+    }
+  }
+}

--- a/features/wearos/calculator-fees/src/main/res/values-es/strings.xml
+++ b/features/wearos/calculator-fees/src/main/res/values-es/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2024 Marlonlom
+  SPDX-License-Identifier: Apache-2.0
+-->
+<resources>
+  <string name="text_fees">Tarifas (COP)</string>
+  <string name="text_price_range">De %1$s a %2$s</string>
+</resources>

--- a/features/wearos/calculator-fees/src/main/res/values/strings.xml
+++ b/features/wearos/calculator-fees/src/main/res/values/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2024 Marlonlom
+  SPDX-License-Identifier: Apache-2.0
+-->
+<resources>
+  <string name="text_fee_percentage" translatable="false">%1$.0f%%</string>
+  <string name="text_fees">Fees (COP)</string>
+  <string name="text_price_range">From %1$s to %2$s</string>
+</resources>

--- a/features/wearos/calculator-fees/src/test/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/domain/CalculatorFeesProviderTest.kt
+++ b/features/wearos/calculator-fees/src/test/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/domain/CalculatorFeesProviderTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.wearos.calculator.fees.domain
+
+import dev.marlonlom.mocca.calculator.Calculator
+import dev.marlonlom.mocca.calculator.model.OrderFees
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class CalculatorFeesProviderTest {
+
+  @Test
+  fun provideFees_shouldReturnNonEmptyListMappedFromOrderFees() {
+    val result = CalculatorFeesProvider.provideFees()
+    assertNotNull(result)
+    assertEquals(OrderFees.entries.size, result.size)
+  }
+
+  @Test
+  fun provideFees_shouldCorrectlyMapEnumPropertiesToDomainData() {
+    val result = CalculatorFeesProvider.provideFees()
+    OrderFees.entries.forEachIndexed { index, expectedEnum ->
+      val actualDomainData = result[index]
+      assertEquals(expectedEnum.min, actualDomainData.min, 0.0)
+      assertEquals(expectedEnum.max, actualDomainData.max, 0.0)
+      assertEquals(expectedEnum.fixedFee, actualDomainData.fixedFee, 0.0)
+      assertEquals(expectedEnum.haveVariableFee, actualDomainData.haveVariableFee)
+    }
+  }
+
+  @Test
+  fun provideFees_whenHaveVariableFeeIsTrue_shouldApplyVariableFeeFactor() {
+    val result = CalculatorFeesProvider.provideFees()
+    val itemsWithVariableFee = result.filter { it.haveVariableFee }
+    assertTrue("Test setup warning: No OrderFees entry has haveVariableFee = true", itemsWithVariableFee.isNotEmpty())
+    itemsWithVariableFee.forEach { domainData ->
+      assertEquals(Calculator.VARIABLE_FEE_FACTOR, domainData.variableFeeFactor, 0.0)
+    }
+  }
+
+  @Test
+  fun provideFees_whenHaveVariableFeeIsFalse_shouldApplyZeroVariableFeeFactor() {
+    val result = CalculatorFeesProvider.provideFees()
+    val itemsWithoutVariableFee = result.filter { !it.haveVariableFee }
+    assertTrue(
+      "Test setup warning: No OrderFees entry has haveVariableFee = false",
+      itemsWithoutVariableFee.isNotEmpty(),
+    )
+    itemsWithoutVariableFee.forEach { domainData ->
+      assertEquals(0.0, domainData.variableFeeFactor, 0.0)
+    }
+  }
+}

--- a/features/wearos/calculator-fees/src/test/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/domain/ColombianPesoFormatterTest.kt
+++ b/features/wearos/calculator-fees/src/test/kotlin/dev/marlonlom/mocca/wearos/calculator/fees/domain/ColombianPesoFormatterTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.mocca.wearos.calculator.fees.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class ColombianPesoFormatterTest {
+
+  @Test
+  fun formatCOP_shouldFormatZero() {
+    val result = ColombianPesoFormatter.formatCOP(0)
+    assertEquals(true, result.contains("0"))
+  }
+
+  @Test
+  fun formatCOP_shouldFormatPositiveValue() {
+    val result = ColombianPesoFormatter.formatCOP(1500)
+    assertEquals(true, result.contains("1.500") || result.contains("1500"))
+  }
+
+  @Test
+  fun format_underThousand_returnsRawNumberWithSymbol() {
+    val result = ColombianPesoFormatter.format(999)
+    assertEquals("$999", result)
+  }
+
+  @Test
+  fun format_thousands_returnsKFormat() {
+    val result = ColombianPesoFormatter.format(1500)
+    assertEquals("$1.5K", result)
+  }
+
+  @Test
+  fun format_exactThousand_hasNoDecimal() {
+    val result = ColombianPesoFormatter.format(2000)
+    assertEquals("$2K", result)
+  }
+
+  @Test
+  fun format_millions_returnsMFormat() {
+    val result = ColombianPesoFormatter.format(2_500_000)
+    assertEquals("$2.5M", result)
+  }
+
+  @Test
+  fun format_exactMillion_hasNoDecimal() {
+    val result = ColombianPesoFormatter.format(3_000_000)
+    assertEquals("$3M", result)
+  }
+
+  @Test
+  fun format_largeMillion_truncatesToOneDecimal() {
+    val result = ColombianPesoFormatter.format(1_555_000)
+    assertEquals("$1.5M", result)
+  }
+
+  @Test
+  fun format_allowsCustomSymbol() {
+    val result = ColombianPesoFormatter.format(1500, "COP ")
+    assertEquals("COP 1.5K", result)
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,7 @@ include(
 include(
   ":apps:wearos",
   ":features:wearos:calculator-input",
+  ":features:wearos:calculator-fees",
   ":features:wearos:calculator-output",
   ":features:wearos:ui"
 )


### PR DESCRIPTION
## Proposed Changes
This PR introduces the new `calculator-fees` feature module for the Wear OS app and implements its core user interface. 

### Key Modifications:
* **Build Configuration**: Included `:features:wearos:calculator-fees` in the root `settings.gradle.kts`.
* **App Dependency**: Added the new module dependency to `apps/wearos/build.gradle.kts`.
* **UI Implementation**: Developed the standalone calculation fees list screen tailored for wearable viewports.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Build configuration update

## How Has This Been Tested?
- [x] Verified successful Gradle sync and project compilation.
- [x] Tested the UI layout on Wear OS emulators (Round and Square).