### PR TITLE
refactor(convention): introduce internal android macrobenchmark convention plugin

### DIFF
--- a/benchmarks/macro/mobile/build.gradle.kts
+++ b/benchmarks/macro/mobile/build.gradle.kts
@@ -5,58 +5,11 @@
 
 @file:Suppress("UnstableApiUsage")
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
-
 plugins {
-  alias(libs.plugins.android.test)
+  id("mocca.android.macrobenchmark")
 }
 
 android {
   namespace = "dev.marlonlom.mocca.macrobenchmarks.mobile"
-  compileSdk = 36
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-
-  defaultConfig {
-    minSdk = 24
-    targetSdk = 36
-    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-  }
-
-  buildTypes {
-    // This benchmark buildType is used for benchmarking, and should function like your
-    // release build (for example, with minification on). It"s signed with a debug key
-    // for easy local/CI testing.
-    create("benchmark") {
-      isDebuggable = true
-      signingConfig = getByName("debug").signingConfig
-      matchingFallbacks += listOf("release")
-    }
-  }
-
   targetProjectPath = ":apps:mobile"
-  experimentalProperties["android.experimental.self-instrumenting"] = true
-}
-
-tasks.withType<KotlinJvmCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_17)
-  }
-}
-
-dependencies {
-  implementation(libs.androidx.benchmark.macro.junit4)
-  implementation(libs.androidx.test.ext.junit)
-  implementation(libs.androidx.test.espresso.core)
-  implementation(libs.androidx.test.uiautomator)
-}
-
-androidComponents {
-  beforeVariants(selector().all()) {
-    it.enable = it.buildType == "benchmark"
-  }
 }

--- a/benchmarks/macro/wearos/build.gradle.kts
+++ b/benchmarks/macro/wearos/build.gradle.kts
@@ -5,59 +5,11 @@
 
 @file:Suppress("UnstableApiUsage")
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
-
 plugins {
-  alias(libs.plugins.android.test)
+  id("mocca.android.macrobenchmark")
 }
 
 android {
   namespace = "dev.marlonlom.mocca.macrobenchmarks.wearos"
-  compileSdk = 36
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-
-  defaultConfig {
-    minSdk = 24
-    targetSdk = 36
-
-    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-  }
-
-  buildTypes {
-    // This benchmark buildType is used for benchmarking, and should function like your
-    // release build (for example, with minification on). It"s signed with a debug key
-    // for easy local/CI testing.
-    create("benchmark") {
-      isDebuggable = true
-      signingConfig = getByName("debug").signingConfig
-      matchingFallbacks += listOf("release")
-    }
-  }
-
   targetProjectPath = ":apps:wearos"
-  experimentalProperties["android.experimental.self-instrumenting"] = true
-}
-
-tasks.withType<KotlinJvmCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_17)
-  }
-}
-
-dependencies {
-  implementation(libs.androidx.benchmark.macro.junit4)
-  implementation(libs.androidx.test.ext.junit)
-  implementation(libs.androidx.test.espresso.core)
-  implementation(libs.androidx.test.uiautomator)
-}
-
-androidComponents {
-  beforeVariants(selector().all()) {
-    it.enable = it.buildType == "benchmark"
-  }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -81,5 +81,10 @@ gradlePlugin {
       id = "mocca.spotless"
       implementationClass = "dev.marlonlom.mocca.plugins.utils.SpotlessPlugin"
     }
+    /* benchmark modules */
+    register("androidMacroBenchmark") {
+      id = "mocca.android.macrobenchmark"
+      implementationClass = "dev.marlonlom.mocca.plugins.benchmarks.AndroidMacroBenchmarkPlugin"
+    }
   }
 }

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/configs/Config.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/configs/Config.kt
@@ -24,6 +24,11 @@ object Config {
     minSdkVersion = 30
   )
 
+  /** Configuration for Android macrobenchmark build parameters. */
+  val macrobenchmark = AndroidConfig(
+    minSdkVersion = 24
+  )
+
   /** Configuration for JVM-related build parameters. */
   val jvm = JvmConfig()
 }

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/benchmarks/AndroidMacroBenchmarkPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/benchmarks/AndroidMacroBenchmarkPlugin.kt
@@ -33,7 +33,7 @@ class AndroidMacroBenchmarkPlugin : Plugin<Project> {
       }
 
       extensions.configure<TestExtension> {
-        compileSdk = Config.mobile.compileSdkVersion
+        compileSdk = Config.macrobenchmark.compileSdkVersion
 
         compileOptions {
           sourceCompatibility = Config.jvm.javaVersion
@@ -41,9 +41,9 @@ class AndroidMacroBenchmarkPlugin : Plugin<Project> {
         }
 
         defaultConfig {
-          minSdk = Config.mobile.minSdkVersion
-          targetSdk = Config.mobile.targetSdkVersion
-          testInstrumentationRunner = Config.mobile.testInstrumentationRunner
+          minSdk = Config.macrobenchmark.minSdkVersion
+          targetSdk = Config.macrobenchmark.targetSdkVersion
+          testInstrumentationRunner = Config.macrobenchmark.testInstrumentationRunner
         }
 
         buildTypes {

--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/benchmarks/AndroidMacroBenchmarkPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/mocca/plugins/benchmarks/AndroidMacroBenchmarkPlugin.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.marlonlom.mocca.plugins.benchmarks
+
+import com.android.build.api.dsl.TestExtension
+import com.android.build.api.variant.TestAndroidComponentsExtension
+import dev.marlonlom.mocca.configs.Config
+import dev.marlonlom.mocca.extensions.versionCatalog
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+/**
+ * A convention plugin for configuring Android Macrobenchmark modules.
+ *
+ * @author marlonlom
+ */
+class AndroidMacroBenchmarkPlugin : Plugin<Project> {
+
+  @Suppress("UnstableApiUsage")
+  override fun apply(project: Project) {
+    with(project) {
+      with(pluginManager) {
+        apply("com.android.test")
+        apply("mocca.spotless")
+      }
+
+      extensions.configure<TestExtension> {
+        compileSdk = Config.mobile.compileSdkVersion
+
+        compileOptions {
+          sourceCompatibility = Config.jvm.javaVersion
+          targetCompatibility = Config.jvm.javaVersion
+        }
+
+        defaultConfig {
+          minSdk = Config.mobile.minSdkVersion
+          targetSdk = Config.mobile.targetSdkVersion
+          testInstrumentationRunner = Config.mobile.testInstrumentationRunner
+        }
+
+        buildTypes {
+          create("benchmark") {
+            isDebuggable = true
+            signingConfig = getByName("debug").signingConfig
+            matchingFallbacks += listOf("release")
+          }
+        }
+
+        experimentalProperties["android.experimental.self-instrumenting"] = true
+      }
+
+      tasks.withType<KotlinJvmCompile>().configureEach {
+        compilerOptions {
+          jvmTarget.set(JvmTarget.fromTarget(Config.jvm.kotlinJvm))
+        }
+      }
+
+      val libs = versionCatalog()
+      dependencies {
+        add("implementation", libs.findLibrary("androidx-benchmark-macro-junit4").get())
+        add("implementation", libs.findLibrary("androidx-test-ext-junit").get())
+        add("implementation", libs.findLibrary("androidx-test-espresso-core").get())
+        add("implementation", libs.findLibrary("androidx-test-uiautomator").get())
+      }
+
+      extensions.configure<TestAndroidComponentsExtension> {
+        beforeVariants(selector().all()) {
+          it.enable = it.buildType == "benchmark"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary
This PR introduces the `AndroidMacroBenchmarkPlugin` to consolidate and centralize shared build configurations for our macrobenchmark modules. By abstracting this logic into `build-logic`, we remove significant boilerplate duplication from the mobile and Wear OS benchmark modules.

### Changes Made
- **Build Logic:** - Created `AndroidMacroBenchmarkPlugin.kt` to handle `com.android.test` configuration, SDK versions via `Config`, custom `benchmark` build types, and standard test/UI-automator dependencies.
  - Registered the plugin under the ID `mocca.android.macrobenchmark` in `build-logic/convention/build.gradle.kts`.
- **Benchmark Modules:**
  - Migrated `benchmarks/macro/mobile/build.gradle.kts` to use the new plugin ID and stripped out the redundant setup.
  - Migrated `benchmarks/macro/wearos/build.gradle.kts` similarly, achieving identical build behavior with significantly less code.

### Verification Done
- Run `./gradlew :benchmarks:macro:mobile:assembleBenchmark` to ensure the mobile benchmark target compiles correctly.
- Run `./gradlew :benchmarks:macro:wearos:assembleBenchmark` to verify the Wear OS benchmark target setup.
- Executed spotless checks to ensure compliance with code style rules.